### PR TITLE
feat: add mark comment as answer feature

### DIFF
--- a/src/convex/schema/feedback.schema.ts
+++ b/src/convex/schema/feedback.schema.ts
@@ -13,6 +13,7 @@ export const feedbackSchema = z.object({
 	upvotes: z.number().default(0),
 	boardId: zid('feedbackBoard'),
 	firstCommentId: z.optional(zid('feedbackComment')),
+	answerCommentId: z.optional(zid('feedbackComment')),
 	status: z.enum(['open', 'in-progress', 'closed', 'completed', 'paused']),
 	tags: z.array(z.string()).optional(),
 	searchContent: z.string().optional(),

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -430,7 +430,12 @@ function RouteComponent() {
 
 							<EditorRefProvider>
 								{/* Additional comments */}
-								<CommentsList feedbackId={feedback._id} currentProfileId={currentProfile?._id} />
+								<CommentsList
+									feedbackId={feedback._id}
+									currentProfileId={currentProfile?._id}
+									answerCommentId={feedback.answerCommentId}
+									canMarkAnswer={canEditStatus}
+								/>
 
 								{/* Comment form */}
 								<CommentForm feedbackId={feedback._id} isAuthenticated={!!currentProfile} />


### PR DESCRIPTION
## Summary
- Add `answerCommentId` field to feedback schema to track which comment is marked as the answer
- Add `setAnswerComment` mutation with permission checks (feedback author OR canEdit)
- Add "Mark as answer" / "Unmark as answer" dropdown menu option for authorized users
- Display green "Answer" badge on marked comments with modern styling (green border, gradient well)

## Test plan
- [ ] As feedback author: can mark/unmark any comment as answer
- [ ] As project admin: can mark/unmark any comment as answer
- [ ] As regular user: cannot see mark as answer option
- [ ] Visual indicator shows on the answer comment (green badge, border, gradient)
- [ ] Only one comment can be marked as answer at a time
- [ ] Cannot mark the initial feedback comment as answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)