### PR TITLE
Refactor route loading boundaries

### DIFF
--- a/src/components/route-pending.tsx
+++ b/src/components/route-pending.tsx
@@ -1,0 +1,60 @@
+type RoutePendingProps = {
+	variant?: 'page' | 'detail' | 'form' | 'sidebar';
+};
+
+export function RoutePending({ variant = 'page' }: RoutePendingProps) {
+	if (variant === 'sidebar') {
+		return (
+			<div className='container py-8'>
+				<div className='grid grid-cols-1 gap-8 md:grid-cols-12'>
+					<div className='space-y-4 md:col-span-3'>
+						<div className='h-10 w-full animate-pulse rounded bg-muted' />
+						<div className='h-48 w-full animate-pulse rounded bg-muted' />
+					</div>
+					<div className='space-y-4 md:col-span-9'>
+						<div className='h-28 w-full animate-pulse rounded-lg bg-muted' />
+						<div className='h-12 w-full animate-pulse rounded bg-muted' />
+						<div className='h-32 w-full animate-pulse rounded bg-muted' />
+						<div className='h-32 w-full animate-pulse rounded bg-muted' />
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	if (variant === 'detail') {
+		return (
+			<div className='container py-10'>
+				<div className='mx-auto max-w-240 animate-pulse px-4'>
+					<div className='h-8 w-32 rounded bg-muted' />
+					<div className='mt-4 h-12 w-3/4 rounded bg-muted' />
+					<div className='mt-3 h-5 w-1/3 rounded bg-muted' />
+					<div className='mt-10 h-64 rounded-lg bg-muted' />
+				</div>
+			</div>
+		);
+	}
+
+	if (variant === 'form') {
+		return (
+			<div className='container py-10'>
+				<div className='mx-auto max-w-2xl animate-pulse space-y-4'>
+					<div className='h-10 w-56 rounded bg-muted' />
+					<div className='h-12 w-full rounded bg-muted' />
+					<div className='h-12 w-full rounded bg-muted' />
+					<div className='h-64 w-full rounded bg-muted' />
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className='container py-10'>
+			<div className='mx-auto max-w-240 animate-pulse px-4'>
+				<div className='h-12 w-56 rounded bg-muted' />
+				<div className='mt-8 h-32 w-full rounded bg-muted' />
+				<div className='mt-6 h-32 w-full rounded bg-muted' />
+			</div>
+		</div>
+	);
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -17,9 +17,7 @@ export function getRouter() {
 	if (!CONVEX_URL) {
 		throw new Error('missing VITE_CONVEX_URL envar');
 	}
-	const convex = new ConvexReactClient(CONVEX_URL, {
-		expectAuth: true,
-	});
+	const convex = new ConvexReactClient(CONVEX_URL);
 
 	const convexQueryClient = new ConvexQueryClient(convex);
 
@@ -28,7 +26,7 @@ export function getRouter() {
 			queries: {
 				queryKeyHashFn: convexQueryClient.hashFn(),
 				queryFn: convexQueryClient.queryFn(),
-				gcTime: 5000,
+				gcTime: 5 * 60_000,
 			},
 		},
 	});

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -26,6 +26,7 @@ import {
 	sanitizeEditorContent,
 } from '@/components/editor';
 import { ProfileLinkOrUnknown } from '@/components/profile-link';
+import { RoutePending } from '@/components/route-pending';
 import { SidebarSection } from '@/components/sidebar-section';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -339,20 +340,20 @@ function FirstCommentItem({
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/$slug/')({
 	loader: async ({ context, params }) => {
-		const project = await context.queryClient.ensureQueryData(
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		if (!project?.project?._id) {
+		if (!projectData?.project?._id) {
 			throw notFound();
 		}
 
 		const feedbackData = await context.queryClient.ensureQueryData(
 			convexQuery(api.feedback.getBySlug, {
-				projectId: project.project._id,
+				projectId: projectData.project._id,
 				slug: params.slug,
 			})
 		);
@@ -360,15 +361,14 @@ export const Route = createFileRoute('/@{$org}/$project/feedback/$slug/')({
 		if (!feedbackData) {
 			throw notFound();
 		}
-
-		return { feedbackData };
 	},
+	pendingComponent: () => <RoutePending variant='detail' />,
+	pendingMs: 150,
 	component: RouteComponent,
 });
 
 function RouteComponent() {
 	const params = Route.useParams();
-	const { feedbackData: loaderData } = Route.useLoaderData();
 
 	const { data: projectData } = useSuspenseQuery(
 		convexQuery(api.project.getDetails, {
@@ -377,12 +377,20 @@ function RouteComponent() {
 		})
 	);
 
+	if (!projectData?.project?._id) {
+		throw notFound();
+	}
+
 	const { data: feedbackData } = useSuspenseQuery(
 		convexQuery(api.feedback.getBySlug, {
-			projectId: projectData?.project?._id!,
+			projectId: projectData.project._id,
 			slug: params.slug,
 		})
 	);
+
+	if (!feedbackData) {
+		throw notFound();
+	}
 
 	// Get current user's profile for highlighting their emotes
 	const { data: currentProfile } = useQuery(convexQuery(api.profile.findMyProfile, {}));
@@ -407,13 +415,7 @@ function RouteComponent() {
 		})
 	);
 
-	const data = feedbackData ?? loaderData;
-
-	if (!data) {
-		return <div className='container py-10'>Feedback not found.</div>;
-	}
-
-	const { feedback, author, board, firstComment, assignedProfile, hasUpvoted } = data;
+	const { feedback, author, board, firstComment, assignedProfile, hasUpvoted } = feedbackData;
 
 	// Find the first comment with emotes from the comments list
 	const firstCommentWithEmotes = comments?.find((c) => c._id === firstComment?._id);

--- a/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
@@ -5,14 +5,17 @@ import { ChevronLeft } from 'lucide-react';
 
 import { api } from '~api';
 import { NotFound } from '@/components/_not-found';
+import { RoutePending } from '@/components/route-pending';
 import { Id } from '@/convex/_generated/dataModel';
 
 import { EditBoardForm } from './-components/edit-board-form';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/boards/$board/edit')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
-		const board = await context.queryClient.ensureQueryData(
+		const boardData = await context.queryClient.ensureQueryData(
 			convexQuery(api.feedbackBoard.get, {
 				_id: params.board,
 				projectSlug: params.project,
@@ -20,8 +23,7 @@ export const Route = createFileRoute('/@{$org}/$project/feedback/boards/$board/e
 			})
 		);
 
-		if (!board) {
-			// throw new Error();
+		if (!boardData) {
 			throw notFound();
 		}
 	},
@@ -39,7 +41,9 @@ function RouteComponent() {
 		})
 	);
 
-	if (!board) throw new Error('No board found.');
+	if (!board) {
+		throw notFound();
+	}
 
 	return (
 		<div className='container'>

--- a/src/routes/@{$org}/$project/feedback/boards/$board/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/index.tsx
@@ -1,30 +1,49 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, notFound } from '@tanstack/react-router';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
+import { Id } from '@/convex/_generated/dataModel';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/boards/$board/')({
+	pendingComponent: () => <RoutePending variant='detail' />,
+	pendingMs: 150,
+	loader: async ({ context, params }) => {
+		const boardData = await context.queryClient.ensureQueryData(
+			convexQuery(api.feedbackBoard.get, {
+				_id: params.board,
+				projectSlug: params.project,
+				orgSlug: params.org,
+			})
+		);
+
+		if (!boardData) {
+			throw notFound();
+		}
+	},
 	component: RouteComponent,
 });
 
 function RouteComponent() {
-	const { data: feedback } = useSuspenseQuery(
-		convexQuery(api.features.feedback, {
-			projectSlug: Route.useParams().project,
+	const { org, project, board } = Route.useParams();
+
+	const { data: boardData } = useSuspenseQuery(
+		convexQuery(api.feedbackBoard.get, {
+			_id: board as Id<'feedbackBoard'>,
+			projectSlug: project,
+			orgSlug: org,
 		})
 	);
 
-	if (!feedback?.boards) throw new Error('No boards found');
-
-	const board = feedback.boards.find((board) => board._id === Route.useParams().board);
-
-	if (!board) throw new Error('No board found');
+	if (!boardData) {
+		throw notFound();
+	}
 
 	return (
 		<div className='container'>
 			<pre>
-				<code>{JSON.stringify(board, null, 2)}</code>
+				<code>{JSON.stringify(boardData, null, 2)}</code>
 			</pre>
 		</div>
 	);

--- a/src/routes/@{$org}/$project/feedback/boards/$board/route.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/route.tsx
@@ -1,23 +1,8 @@
-import { convexQuery } from '@convex-dev/react-query';
-import { createFileRoute, notFound, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { api } from '~api';
 import { NotFound } from '@/components/_not-found';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/boards/$board')({
-	loader: async ({ context, params }) => {
-		const board = await context.queryClient.ensureQueryData(
-			convexQuery(api.feedbackBoard.get, {
-				_id: params.board,
-				projectSlug: params.project,
-				orgSlug: params.org,
-			})
-		);
-
-		if (!board) {
-			throw notFound();
-		}
-	},
 	component: RouteComponent,
 	errorComponent: ({ error }) => {
 		return <div>There was an error: {error.message}</div>;

--- a/src/routes/@{$org}/$project/feedback/boards/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/index.tsx
@@ -1,8 +1,9 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 import { buttonVariants } from '@/components/ui/button';
 import { Icon, IconName } from '@/icons';
 import Eye from '@/icons/eye';
@@ -11,6 +12,26 @@ import VArrowRight from '@/icons/v-arrow-right';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/boards/')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='page' />,
+	pendingMs: 150,
+	loader: async ({ context, params }) => {
+		const projectData = await context.queryClient.ensureQueryData(
+			convexQuery(api.project.getDetails, {
+				orgSlug: params.org,
+				slug: params.project,
+			})
+		);
+
+		if (!projectData?.project?._id) {
+			throw notFound();
+		}
+
+		await context.queryClient.ensureQueryData(
+			convexQuery(api.feedbackBoard.listProjectBoards, {
+				slug: params.project,
+			})
+		);
+	},
 });
 
 function RouteComponent() {

--- a/src/routes/@{$org}/$project/feedback/boards/route.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/route.tsx
@@ -1,17 +1,8 @@
-import { convexQuery } from '@convex-dev/react-query';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { api } from '~api';
 import { InlineAlert } from '@/components/inline-alert';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/boards')({
-	loader: async ({ context, params }) => {
-		await context.queryClient.ensureQueryData(
-			convexQuery(api.features.feedback, {
-				projectSlug: params.project,
-			})
-		);
-	},
 	component: RouteComponent,
 	errorComponent: () => {
 		return (

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { convexQuery } from '@convex-dev/react-query';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, Link, useRouter } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound, useRouter } from '@tanstack/react-router';
 import { usePaginatedQuery } from 'convex/react';
 import * as z from 'zod';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 import { Button } from '@/components/ui/button';
 import { Id } from '@/convex/_generated/dataModel';
 import { feedbackSelectSchema } from '@/convex/schema/feedback.schema';
@@ -32,44 +33,27 @@ const feedbackSearchParams = z.object({
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/')({
 	validateSearch: feedbackSearchParams,
-	loaderDeps: ({ search }) => ({ search }),
-	loader: async ({ context, params, deps }) => {
-		await context.queryClient.ensureQueryData(
-			convexQuery(api.features.feedback, {
-				projectSlug: params.project,
-			})
-		);
-
-		const boards = await context.queryClient.ensureQueryData(
-			convexQuery(api.feedbackBoard.listProjectBoards, {
-				slug: params.project,
-			})
-		);
-
-		// This will be rewritten 👇
-		const project = await context.queryClient.ensureQueryData(
+	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='sidebar' />,
+	pendingMs: 150,
+	loader: async ({ context, params }) => {
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		const feedback = await context.queryClient.ensureQueryData(
-			convexQuery(api.feedback.listProjectFeedback, {
-				projectId: project?.project?._id!,
-				search: deps.search.search,
-				boardId: boards?.find((b) => b.slug === deps.search.board)?._id ?? 'all',
-				status: deps.search.status,
-				paginationOpts: {
-					numItems: NUM_OF_ITEMS_PER_PAGE,
-					cursor: null,
-				},
+		if (!projectData?.project?._id) {
+			throw notFound();
+		}
+
+		await context.queryClient.ensureQueryData(
+			convexQuery(api.feedbackBoard.listProjectBoards, {
+				slug: params.project,
 			})
 		);
-
-		return { feedback: feedback.page };
 	},
-	component: RouteComponent,
 });
 
 const Notice = ({ icon, children }: { icon: React.JSX.Element; children: React.ReactNode }) => {
@@ -86,11 +70,8 @@ function RouteComponent() {
 	const searchParams = Route.useSearch();
 	const { search, status, board } = searchParams;
 	const { org: orgSlug, project: projectSlug } = Route.useParams();
-	const { feedback: serverResults } = Route.useLoaderData();
 
-	const [feedback, setFeedback] = React.useState(serverResults);
 	const [boardId, setBoardId] = React.useState<Id<'feedbackBoard'> | 'all'>('all');
-	const [loadingFeedback, setLoadingFeedback] = React.useState(false);
 
 	const { data: projectData } = useSuspenseQuery(
 		convexQuery(api.project.getDetails, {
@@ -105,12 +86,11 @@ function RouteComponent() {
 		})
 	);
 
-	// Get current user's profile for authentication status
 	const { data: currentProfile } = useQuery(convexQuery(api.profile.findMyProfile, {}));
 	const isAuthenticated = !!currentProfile;
 
 	if (!projectData?.project?._id) {
-		return null;
+		throw notFound();
 	}
 
 	const feedbackData = usePaginatedQuery(
@@ -127,30 +107,14 @@ function RouteComponent() {
 	);
 
 	React.useEffect(() => {
-		if (feedbackData.status !== 'LoadingFirstPage' && feedbackData.status !== 'LoadingMore') {
-			setFeedback(feedbackData.results);
-		}
-	}, [feedbackData]);
-
-	React.useEffect(() => {
-		if (board) {
+		if (boards) {
 			setBoardId(boards?.find((b) => b.slug === board)?._id ?? 'all');
 		}
-	}, [board]);
+	}, [board, boards]);
 
-	React.useEffect(() => {
-		if (
-			feedbackData.status === 'LoadingFirstPage' ||
-			feedbackData.status === 'LoadingMore' ||
-			searchParams
-		) {
-			setLoadingFeedback(true);
-		}
-
-		if (feedbackData.status !== 'LoadingFirstPage' && feedbackData.status !== 'LoadingMore') {
-			setLoadingFeedback(false);
-		}
-	}, [feedbackData.status, searchParams]);
+	const loadingFeedback =
+		feedbackData.status === 'LoadingFirstPage' || feedbackData.status === 'LoadingMore';
+	const feedback = feedbackData.results;
 
 	return (
 		<div className='container h-full overflow-visible'>

--- a/src/routes/@{$org}/$project/feedback/new/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/new/index.tsx
@@ -1,13 +1,34 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, useRouter } from '@tanstack/react-router';
+import { createFileRoute, notFound, useRouter } from '@tanstack/react-router';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 
 import { CreateFeedbackForm } from './-components/create-feedback-form';
 
 export const Route = createFileRoute('/@{$org}/$project/feedback/new/')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
+	loader: async ({ context, params }) => {
+		const projectDetails = await context.queryClient.ensureQueryData(
+			convexQuery(api.project.getDetails, {
+				orgSlug: params.org,
+				slug: params.project,
+			})
+		);
+
+		if (!projectDetails?.project?._id) {
+			throw notFound();
+		}
+
+		await context.queryClient.ensureQueryData(
+			convexQuery(api.feedbackBoard.listProjectBoards, {
+				slug: params.project,
+			})
+		);
+	},
 });
 
 function RouteComponent() {
@@ -29,7 +50,7 @@ function RouteComponent() {
 	);
 
 	if (!projectDetails?.project) {
-		throw new Error('Project not found: 019a6be9');
+		throw notFound();
 	}
 
 	return (

--- a/src/routes/@{$org}/$project/route.tsx
+++ b/src/routes/@{$org}/$project/route.tsx
@@ -1,24 +1,13 @@
 import React from 'react';
-import { convexQuery } from '@convex-dev/react-query';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { api } from '~api';
 import { NotFound } from '@/components/_not-found';
 import { cn } from '@/lib/utils';
 
 import { DynamicNavigation } from './-components/dynamic-nav';
 
 export const Route = createFileRoute('/@{$org}/$project')({
-	loader: async ({ context, params }) => {
-		await context.queryClient.ensureQueryData(
-			convexQuery(api.project.getDetails, {
-				orgSlug: params.org,
-				slug: params.project,
-			})
-		);
-	},
 	component: RouteComponent,
-	pendingMs: 5000,
 	// pendingComponent: () => {
 	// 	return (
 	// 		<div className='container'>

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { convexQuery, useConvexMutation } from '@convex-dev/react-query';
 import { revalidateLogic } from '@tanstack/react-form';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, redirect, useRouter } from '@tanstack/react-router';
+import { createFileRoute, Navigate, notFound, useRouter } from '@tanstack/react-router';
 import { FileText, X } from 'lucide-react';
 import * as z from 'zod';
 
 import { api } from '~api';
 import { MarkdownEditor, sanitizeEditorContent } from '@/components/editor';
+import { RoutePending } from '@/components/route-pending';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input-shadcn';
@@ -38,44 +39,30 @@ const formSchema = updateSchema.pick({
 type FormSchema = z.infer<typeof formSchema>;
 
 export const Route = createFileRoute('/@{$org}/$project/updates/$slug/edit')({
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
-		const project = await context.queryClient.ensureQueryData(
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		if (!project?.project?._id) {
-			throw redirect({
-				to: '/@{$org}/$project/updates',
-				params: {
-					org: params.org,
-					project: params.project,
-				},
-			});
+		if (!projectData?.project?._id) {
+			throw notFound();
 		}
 
 		const updateData = await context.queryClient.ensureQueryData(
 			convexQuery(api.update.getBySlug, {
-				projectId: project.project._id,
+				projectId: projectData.project._id,
 				slug: params.slug,
 			})
 		);
 
-		// Check if user can edit
-		if (!updateData?.canEdit) {
-			throw redirect({
-				to: '/@{$org}/$project/updates/$slug',
-				params: {
-					org: params.org,
-					project: params.project,
-					slug: params.slug,
-				},
-			});
+		if (!updateData) {
+			throw notFound();
 		}
-
-		return { updateData };
 	},
 	component: RouteComponent,
 });
@@ -92,17 +79,42 @@ function RouteComponent() {
 		})
 	);
 
+	if (!projectData?.project?._id) {
+		return (
+			<Navigate
+				to='/@{$org}/$project/updates'
+				params={{
+					org: orgSlug,
+					project: projectSlug,
+				}}
+			/>
+		);
+	}
+
 	const { data: updateData } = useSuspenseQuery(
 		convexQuery(api.update.getBySlug, {
-			projectId: projectData?.project?._id!,
+			projectId: projectData.project._id,
 			slug,
 		})
 	);
 
+	if (!updateData?.canEdit) {
+		return (
+			<Navigate
+				to='/@{$org}/$project/updates/$slug'
+				params={{
+					org: orgSlug,
+					project: projectSlug,
+					slug,
+				}}
+			/>
+		);
+	}
+
 	const [tagInput, setTagInput] = useState('');
 	const formError = useFormError();
 
-	const { update } = updateData!;
+	const { update } = updateData;
 
 	const [selectedFeedbackIds, setSelectedFeedbackIds] = useState<Id<'feedback'>[]>(
 		update.relatedFeedbackIds ?? []

--- a/src/routes/@{$org}/$project/updates/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/index.tsx
@@ -18,6 +18,7 @@ import { api } from '~api';
 import { EditorContentDisplay, EditorRefProvider } from '@/components/editor';
 import { type EmoteContent } from '@/components/emote';
 import { ProfileLinkOrUnknown } from '@/components/profile-link';
+import { RoutePending } from '@/components/route-pending';
 import { SidebarSection } from '@/components/sidebar-section';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -56,20 +57,20 @@ const DEFAULT_SIDEBAR_STATE: SidebarSections = {
 
 export const Route = createFileRoute('/@{$org}/$project/updates/$slug/')({
 	loader: async ({ context, params }) => {
-		const project = await context.queryClient.ensureQueryData(
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		if (!project?.project?._id) {
+		if (!projectData?.project?._id) {
 			throw notFound();
 		}
 
 		const updateData = await context.queryClient.ensureQueryData(
 			convexQuery(api.update.getBySlug, {
-				projectId: project.project._id,
+				projectId: projectData.project._id,
 				slug: params.slug,
 			})
 		);
@@ -77,15 +78,14 @@ export const Route = createFileRoute('/@{$org}/$project/updates/$slug/')({
 		if (!updateData) {
 			throw notFound();
 		}
-
-		return { updateData };
 	},
+	pendingComponent: () => <RoutePending variant='detail' />,
+	pendingMs: 150,
 	component: RouteComponent,
 });
 
 function RouteComponent() {
 	const params = Route.useParams();
-	const { updateData: loaderData } = Route.useLoaderData();
 	const { state: sidebarState, setSection: setSidebarSection } = useSidebarState(
 		SIDEBAR_STORAGE_KEY,
 		DEFAULT_SIDEBAR_STATE
@@ -98,24 +98,26 @@ function RouteComponent() {
 		})
 	);
 
+	if (!projectData?.project?._id) {
+		throw notFound();
+	}
+
 	const { data: updateData } = useSuspenseQuery(
 		convexQuery(api.update.getBySlug, {
-			projectId: projectData?.project?._id!,
+			projectId: projectData.project._id,
 			slug: params.slug,
 		})
 	);
 
+	if (!updateData) {
+		throw notFound();
+	}
+
 	// Get current user's profile
 	const { data: currentProfile } = useQuery(convexQuery(api.profile.findMyProfile, {}));
 
-	const data = updateData ?? loaderData;
-
-	if (!data) {
-		return <div className='container py-10'>Update not found.</div>;
-	}
-
 	const { update, coverImageUrl, author, relatedFeedback, emoteCounts, commentCount, canEdit } =
-		data;
+		updateData;
 	const isAuthenticated = !!currentProfile;
 	const currentProfileId = currentProfile?._id;
 	const hasRelatedFeedback = relatedFeedback && relatedFeedback.length > 0;

--- a/src/routes/@{$org}/$project/updates/index.tsx
+++ b/src/routes/@{$org}/$project/updates/index.tsx
@@ -1,9 +1,10 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { FileText } from 'lucide-react';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 import { Button } from '@/components/ui/button';
 import CirclePlusOutline from '@/icons/circle-plus-outline';
 import LoaderQuarter from '@/icons/loader-quarter';
@@ -12,25 +13,27 @@ import Missing from '@/icons/missing';
 import { UpdateCard } from './-components/update-card';
 
 export const Route = createFileRoute('/@{$org}/$project/updates/')({
+	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='page' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
-		const project = await context.queryClient.ensureQueryData(
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		if (project?.project?._id) {
-			await context.queryClient.ensureQueryData(
-				convexQuery(api.update.listByProject, {
-					projectId: project.project._id,
-				})
-			);
+		if (!projectData?.project?._id) {
+			throw notFound();
 		}
 
-		return { project };
+		await context.queryClient.ensureQueryData(
+			convexQuery(api.update.listByProject, {
+				projectId: projectData.project._id,
+			})
+		);
 	},
-	component: RouteComponent,
 });
 
 const Notice = ({ icon, children }: { icon: React.JSX.Element; children: React.ReactNode }) => {
@@ -58,12 +61,12 @@ function RouteComponent() {
 		})
 	);
 
+	if (!projectData?.project?._id) {
+		throw notFound();
+	}
+
 	// Get current user's profile for like functionality
 	const { data: currentProfile } = useQuery(convexQuery(api.profile.findMyProfile, {}));
-
-	if (!projectData?.project?._id) {
-		return null;
-	}
 
 	// Handle case where updatesData is an empty array (project not found)
 	const updates = Array.isArray(updatesData) ? [] : updatesData.updates;

--- a/src/routes/@{$org}/$project/updates/new/index.tsx
+++ b/src/routes/@{$org}/$project/updates/new/index.tsx
@@ -1,34 +1,28 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, redirect, useRouter } from '@tanstack/react-router';
+import { createFileRoute, Navigate, notFound, useRouter } from '@tanstack/react-router';
 import { FileText } from 'lucide-react';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 import { Id } from '@/convex/_generated/dataModel';
 
 import { CreateUpdateForm } from './-components/create-update-form';
 
 export const Route = createFileRoute('/@{$org}/$project/updates/new/')({
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
-		const project = await context.queryClient.ensureQueryData(
+		const projectData = await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getDetails, {
 				orgSlug: params.org,
 				slug: params.project,
 			})
 		);
 
-		// Check if user can edit the project
-		if (!project?.permissions?.canEdit) {
-			throw redirect({
-				to: '/@{$org}/$project/updates',
-				params: {
-					org: params.org,
-					project: params.project,
-				},
-			});
+		if (!projectData?.project?._id) {
+			throw notFound();
 		}
-
-		return { project };
 	},
 	component: RouteComponent,
 });
@@ -43,6 +37,18 @@ function RouteComponent() {
 			slug: projectSlug,
 		})
 	);
+
+	if (!projectData?.permissions?.canEdit) {
+		return (
+			<Navigate
+				to='/@{$org}/$project/updates'
+				params={{
+					org: orgSlug,
+					project: projectSlug,
+				}}
+			/>
+		);
+	}
 
 	if (!projectData?.project?._id) {
 		return null;

--- a/src/routes/@{$org}/-components/main-nav.tsx
+++ b/src/routes/@{$org}/-components/main-nav.tsx
@@ -43,7 +43,7 @@ type MainNavProps = {
 		slug: string;
 		name: string;
 	};
-	user: API['profile']['findMyProfile'];
+	user: API['profile']['findMyProfile'] | null | undefined;
 };
 
 export const MainNav = ({ children, user }: MainNavProps) => {

--- a/src/routes/@{$org}/create-project/index.tsx
+++ b/src/routes/@{$org}/create-project/index.tsx
@@ -4,11 +4,14 @@ import { createFileRoute, notFound } from '@tanstack/react-router';
 
 import { api } from '~api';
 import { NotFound } from '@/components/_not-found';
+import { RoutePending } from '@/components/route-pending';
 
 import { CreateProjectForm } from './-create-project-form';
 
 export const Route = createFileRoute('/@{$org}/create-project/')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
 		const orgDetails = await context.queryClient.ensureQueryData(
 			convexQuery(api.org.getDetails, {
@@ -16,17 +19,15 @@ export const Route = createFileRoute('/@{$org}/create-project/')({
 			})
 		);
 
-		if (!orgDetails.permissions.canEdit) {
+		if (!orgDetails?.org || !orgDetails.permissions.canEdit) {
 			throw notFound();
 		}
 
-		const limits = await context.queryClient.ensureQueryData(
+		await context.queryClient.ensureQueryData(
 			convexQuery(api.org.getMyPermission, {
 				slug: params.org,
 			})
 		);
-
-		return { limits };
 	},
 	notFoundComponent: () => <NotFound isContainer />,
 });
@@ -34,15 +35,21 @@ export const Route = createFileRoute('/@{$org}/create-project/')({
 function RouteComponent() {
 	const { org: orgSlug } = Route.useParams();
 
-	const { limits } = Route.useLoaderData();
-
-	if (!limits) return null;
-
 	const { data: orgDetails } = useSuspenseQuery(
 		convexQuery(api.org.getDetails, {
 			slug: orgSlug,
 		})
 	);
+
+	const { data: limits } = useSuspenseQuery(
+		convexQuery(api.org.getMyPermission, {
+			slug: orgSlug,
+		})
+	);
+
+	if (!orgDetails.permissions.canEdit) {
+		throw notFound();
+	}
 
 	if (!orgDetails.org) return null;
 

--- a/src/routes/@{$org}/index.tsx
+++ b/src/routes/@{$org}/index.tsx
@@ -1,9 +1,10 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { ArrowUpRight, CircleCheck, FolderOpen, Settings, User } from 'lucide-react';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 
@@ -12,7 +13,17 @@ import { OrgProjects } from './-components/org-projects';
 
 export const Route = createFileRoute('/@{$org}/')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='page' />,
+	pendingMs: 150,
 	loader: async ({ context, params }) => {
+		const orgDetails = await context.queryClient.ensureQueryData(
+			convexQuery(api.org.getDetails, { slug: params.org })
+		);
+
+		if (!orgDetails?.org) {
+			throw notFound();
+		}
+
 		await context.queryClient.ensureQueryData(
 			convexQuery(api.project.getManyByOrg, {
 				orgSlug: params.org,

--- a/src/routes/@{$org}/route.tsx
+++ b/src/routes/@{$org}/route.tsx
@@ -1,5 +1,6 @@
 import { convexQuery } from '@convex-dev/react-query';
-import { createFileRoute, notFound, Outlet } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 
 import { api } from '~api';
 import { NotFound } from '@/components/_not-found';
@@ -7,25 +8,6 @@ import { NotFound } from '@/components/_not-found';
 import { MainNav } from './-components/main-nav';
 
 export const Route = createFileRoute('/@{$org}')({
-	loader: async ({ context, params }) => {
-		const user = await context.queryClient.ensureQueryData(
-			convexQuery(api.profile.findMyProfile, {})
-		);
-		await context.queryClient
-			.fetchQuery(
-				convexQuery(api.org.getDetails, {
-					slug: params.org,
-				})
-			)
-			.catch((error) => {
-				console.error(error);
-				throw notFound();
-			});
-
-		return {
-			user,
-		};
-	},
 	component: RouteComponent,
 	notFoundComponent: () => <NotFound isContainer />,
 	errorComponent: () => {
@@ -41,7 +23,8 @@ export const Route = createFileRoute('/@{$org}')({
 });
 
 function RouteComponent() {
-	const { user } = Route.useLoaderData();
+	const { data: user } = useQuery(convexQuery(api.profile.findMyProfile, {}));
+
 	return (
 		<div className='flex h-screen w-full flex-col'>
 			<div className='flex w-full flex-1 flex-col'>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -68,7 +68,7 @@ export const Route = createRootRouteWithContext<{
 		],
 	}),
 	beforeLoad: async (ctx) => {
-		const token = await getAuth();
+		const token = typeof document === 'undefined' ? await getAuth() : undefined;
 
 		// During SSR only (the only time serverHttpClient exists),
 		// set the auth token to make HTTP queries with.

--- a/src/routes/_blank/sign-in.tsx
+++ b/src/routes/_blank/sign-in.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { createFileRoute, Link, Navigate } from '@tanstack/react-router';
 import { ChevronLeft } from 'lucide-react';
+import { useConvexAuth } from 'convex/react';
 import * as z from 'zod';
 
 import { Button } from '@/components/ui/button';
@@ -13,17 +14,19 @@ const searchValidator = z.object({
 export const Route = createFileRoute('/_blank/sign-in')({
 	validateSearch: searchValidator,
 	component: RouteComponent,
-	loader: async ({ context }) => {
-		if (context.token) {
-			throw redirect({
-				to: '/',
-			});
-		}
-	},
 });
 
 function RouteComponent() {
 	const search = Route.useSearch();
+	const { isAuthenticated, isLoading } = useConvexAuth();
+
+	if (isLoading) {
+		return null;
+	}
+
+	if (isAuthenticated) {
+		return <Navigate to='/' />;
+	}
 
 	return (
 		<div className='flex h-screen flex-col items-center justify-center'>

--- a/src/routes/create/route.tsx
+++ b/src/routes/create/route.tsx
@@ -1,21 +1,19 @@
-import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
-import { Authenticated, AuthLoading } from 'convex/react';
+import { createFileRoute, Navigate, Outlet, useRouterState } from '@tanstack/react-router';
+import { useConvexAuth } from 'convex/react';
 
 export const Route = createFileRoute('/create')({
 	component: RouteComponent,
-	loader: async ({ context }) => {
-		if (!context.token) {
-			throw redirect({
-				to: '/sign-in',
-			});
-		}
-	},
 });
 
 function RouteComponent() {
+	const { isAuthenticated, isLoading } = useConvexAuth();
+	const pathname = useRouterState({
+		select: (state) => state.location.pathname,
+	});
+
 	return (
 		<>
-			<AuthLoading>
+			{isLoading ? (
 				<div className='relative flex h-screen w-full items-center justify-center'>
 					<div className='absolute top-0 right-0 left-0 z-0 h-64 w-full bg-gradient-to-t from-background to-muted'></div>
 					<svg
@@ -39,10 +37,13 @@ function RouteComponent() {
 						></path>
 					</svg>
 				</div>
-			</AuthLoading>
-			<Authenticated>
+			) : null}
+			{!isLoading && !isAuthenticated ? (
+				<Navigate to='/sign-in' search={{ redirect: pathname }} />
+			) : null}
+			{isAuthenticated ? (
 				<Outlet />
-			</Authenticated>
+			) : null}
 		</>
 	);
 }

--- a/src/routes/create/team/index.tsx
+++ b/src/routes/create/team/index.tsx
@@ -3,11 +3,14 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { api } from '~api';
+import { RoutePending } from '@/components/route-pending';
 
 import { CreateTeamForm } from './-components/create-team-form';
 
 export const Route = createFileRoute('/create/team/')({
 	component: RouteComponent,
+	pendingComponent: () => <RoutePending variant='form' />,
+	pendingMs: 150,
 	loader: async ({ context }) => {
 		await context.queryClient.ensureQueryData(convexQuery(api.org.findMyOrgs, {}));
 	},

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,25 +1,29 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, Navigate, useRouterState } from '@tanstack/react-router';
+import { useConvexAuth } from 'convex/react';
 
 import { api } from '~api';
 import { authClient } from '@/lib/auth/auth-client';
 
 export const Route = createFileRoute('/home')({
-	beforeLoad: async ({ context }) => {
-		if (!context.token) {
-			throw redirect({
-				to: '/sign-in',
-			});
-		}
-	},
 	component: RouteComponent,
-	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(convexQuery(api.profile.findMyProfile, {}));
-	},
 });
 
 function RouteComponent() {
+	const { isAuthenticated, isLoading } = useConvexAuth();
+	const pathname = useRouterState({
+		select: (state) => state.location.pathname,
+	});
+
+	if (isLoading) {
+		return null;
+	}
+
+	if (!isAuthenticated) {
+		return <Navigate to='/sign-in' search={{ redirect: pathname }} />;
+	}
+
 	const { data: user } = useSuspenseQuery(convexQuery(api.profile.findMyProfile, {}));
 
 	const { data: orgs } = authClient.useListOrganizations();

--- a/src/routes/playground.tsx
+++ b/src/routes/playground.tsx
@@ -6,9 +6,6 @@ import { api } from '~api';
 
 export const Route = createFileRoute('/playground')({
 	component: RouteComponent,
-	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(convexQuery(api.profile.findMyProfile, {}));
-	},
 });
 
 function RouteComponent() {

--- a/src/routes/profile/settings/index.tsx
+++ b/src/routes/profile/settings/index.tsx
@@ -1,6 +1,7 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, Navigate, useRouterState } from '@tanstack/react-router';
+import { useConvexAuth } from 'convex/react';
 
 import { api } from '~api';
 
@@ -8,16 +9,22 @@ import { UserEditForm } from './-components/user-edit-form';
 
 export const Route = createFileRoute('/profile/settings/')({
 	component: RouteComponent,
-	loader: async ({ context }) => {
-		if (!context.token) {
-			throw redirect({
-				to: '/sign-in',
-			});
-		}
-	},
 });
 
 function RouteComponent() {
+	const { isAuthenticated, isLoading } = useConvexAuth();
+	const pathname = useRouterState({
+		select: (state) => state.location.pathname,
+	});
+
+	if (isLoading) {
+		return null;
+	}
+
+	if (!isAuthenticated) {
+		return <Navigate to='/sign-in' search={{ redirect: pathname }} />;
+	}
+
 	const { data: profile } = useSuspenseQuery(convexQuery(api.profile.findMyProfile, {}));
 
 	if (!profile) return null;


### PR DESCRIPTION
## Summary
- remove blocking layout-level route fetches and client-side auth-gated route loaders
- move critical data prefetch back to page routes with `ensureQueryData` and `notFound()` handling
- add consistent route-level pending components for loader-backed pages

## Validation
- `pnpm -s tsc --noEmit`

## Notes
- left unrelated `.cursor/rules/convex_rules.mdc` worktree changes out of this PR
- `authClient`-backed pages were intentionally not refactored in this pass