### PR TITLE
[codex] Address auth SSR review follow-ups

### DIFF
--- a/convex/functions/auth.ts
+++ b/convex/functions/auth.ts
@@ -10,6 +10,7 @@ import {
   getOAuthProxyProductionUrlEnv,
   getOAuthProxySecretEnv,
   getTrustedOrigins,
+  isTrustedOrigin,
 } from '../lib/get-env';
 import authConfig from './auth.config';
 import { defineAuth } from './generated/auth';
@@ -27,10 +28,8 @@ function isSuperAdminEmail(email: string) {
 function forwardedAuthRequestUrl(request: Request | undefined) {
   if (!request) return null;
 
-  const forwardedHost =
-    request.headers.get('x-better-auth-forwarded-host') ?? request.headers.get('x-forwarded-host');
-  const forwardedProto =
-    request.headers.get('x-better-auth-forwarded-proto') ?? request.headers.get('x-forwarded-proto');
+  const forwardedHost = request.headers.get('x-better-auth-forwarded-host');
+  const forwardedProto = request.headers.get('x-better-auth-forwarded-proto');
 
   if (!forwardedHost || !forwardedProto) return null;
 
@@ -40,6 +39,7 @@ function forwardedAuthRequestUrl(request: Request | undefined) {
   try {
     const url = new URL(request.url);
     const host = forwardedHost.replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+    if (!isTrustedOrigin(`${protocol}://${host}`)) return null;
     return `${protocol}://${host}${url.pathname}${url.search}`;
   } catch {
     return null;

--- a/convex/lib/get-env.ts
+++ b/convex/lib/get-env.ts
@@ -100,10 +100,15 @@ function getLoopbackOrigins(siteUrl: string) {
 }
 
 function getLoopbackHosts(siteUrl: string) {
-  return getLoopbackOrigins(siteUrl).map(hostnameFromOriginPattern);
+  if (getLoopbackOrigins(siteUrl).length === 0) return [];
+  return ['localhost:*', '127.0.0.1:*', '[::1]:*'];
 }
 
 function hostnameFromOriginPattern(origin: string) {
+  if (origin.includes('*')) {
+    return normalizeHostPattern(origin);
+  }
+
   try {
     return new URL(origin).host;
   } catch {

--- a/src/lib/convex/auth-server.ts
+++ b/src/lib/convex/auth-server.ts
@@ -1,10 +1,19 @@
 import { convexBetterAuthReactStart } from 'kitcn/auth/start';
 
-function getAuth() {
+function createAuth() {
   return convexBetterAuthReactStart({
     convexUrl: import.meta.env.VITE_CONVEX_URL!,
     convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
   });
+}
+
+type AuthHelpers = ReturnType<typeof createAuth>;
+
+let authSingleton: AuthHelpers | undefined;
+
+function getAuth() {
+  authSingleton ??= createAuth();
+  return authSingleton;
 }
 
 export function rewriteAuthRedirectLocation({
@@ -94,15 +103,16 @@ export async function handler(request: Request) {
   });
 }
 
-type AuthHelpers = ReturnType<typeof getAuth>;
+export const getToken: AuthHelpers['getToken'] = () => getAuth().getToken();
 
-export const getToken: AuthHelpers['getToken'] = (() => getAuth().getToken()) as AuthHelpers['getToken'];
+export const fetchAuthQuery: AuthHelpers['fetchAuthQuery'] = (...args) => {
+  return getAuth().fetchAuthQuery(...args);
+};
 
-export const fetchAuthQuery: AuthHelpers['fetchAuthQuery'] = ((...args: any[]) =>
-  (getAuth().fetchAuthQuery as any).apply(getAuth(), args)) as AuthHelpers['fetchAuthQuery'];
+export const fetchAuthMutation: AuthHelpers['fetchAuthMutation'] = (...args) => {
+  return getAuth().fetchAuthMutation(...args);
+};
 
-export const fetchAuthMutation: AuthHelpers['fetchAuthMutation'] = ((...args: any[]) =>
-  (getAuth().fetchAuthMutation as any).apply(getAuth(), args)) as AuthHelpers['fetchAuthMutation'];
-
-export const fetchAuthAction: AuthHelpers['fetchAuthAction'] = ((...args: any[]) =>
-  (getAuth().fetchAuthAction as any).apply(getAuth(), args)) as AuthHelpers['fetchAuthAction'];
+export const fetchAuthAction: AuthHelpers['fetchAuthAction'] = (...args) => {
+  return getAuth().fetchAuthAction(...args);
+};

--- a/src/lib/convex/server.ts
+++ b/src/lib/convex/server.ts
@@ -14,6 +14,14 @@ type ConvexLoaderQueryOptions = {
   [key: string]: unknown
 }
 
+type ServerConvexClient = {
+  query: (name: string, args: Record<string, unknown>) => Promise<unknown>
+  setAuth: (token: string) => void
+  setFetchOptions: (options: { cache: "no-store" }) => void
+}
+
+const serverClientCache = new WeakMap<QueryClient, Map<string, ServerConvexClient>>()
+
 function getConvexQueryParts(queryKey: readonly unknown[]) {
   const [kind, functionName, args] = queryKey
 
@@ -40,7 +48,35 @@ function shouldSkipForMissingAuth(
   )
 }
 
+function getServerConvexClient(
+  queryClient: QueryClient,
+  convexUrl: string,
+  token: LoaderToken
+) {
+  const cacheKey = `${convexUrl}\0${token ?? ""}`
+  let queryClientCache = serverClientCache.get(queryClient)
+
+  if (!queryClientCache) {
+    queryClientCache = new Map()
+    serverClientCache.set(queryClient, queryClientCache)
+  }
+
+  const cached = queryClientCache.get(cacheKey)
+  if (cached) return cached
+
+  const client = new ConvexHttpClient(convexUrl) as unknown as ServerConvexClient
+  client.setFetchOptions({ cache: "no-store" })
+
+  if (token) {
+    client.setAuth(token)
+  }
+
+  queryClientCache.set(cacheKey, client)
+  return client
+}
+
 async function runServerQuery<TData>(
+  queryClient: QueryClient,
   options: ConvexLoaderQueryOptions,
   token: LoaderToken
 ) {
@@ -54,20 +90,9 @@ async function runServerQuery<TData>(
   }
 
   const { args, functionName } = getConvexQueryParts(options.queryKey)
-  const client = new ConvexHttpClient(convexUrl)
-  const serverClient = client as unknown as {
-    query: (name: string, args: Record<string, unknown>) => Promise<TData>
-    setAuth: (token: string) => void
-    setFetchOptions: (options: { cache: "no-store" }) => void
-  }
+  const serverClient = getServerConvexClient(queryClient, convexUrl, token)
 
-  serverClient.setFetchOptions({ cache: "no-store" })
-
-  if (token) {
-    serverClient.setAuth(token)
-  }
-
-  return serverClient.query(functionName, args as Record<string, unknown>)
+  return serverClient.query(functionName, args as Record<string, unknown>) as Promise<TData>
 }
 
 export async function fetchConvexLoaderQuery<TData>(
@@ -80,12 +105,13 @@ export async function fetchConvexLoaderQuery<TData>(
   }
 
   if (typeof window !== "undefined") {
+    // Kitcn installs ConvexQueryClient.queryFn() as the default client queryFn.
     return queryClient.ensureQueryData(options as never) as Promise<TData>
   }
 
   return queryClient.fetchQuery({
     ...options,
-    queryFn: () => runServerQuery(options, token),
+    queryFn: () => runServerQuery(queryClient, options, token),
   } as never) as Promise<TData>
 }
 


### PR DESCRIPTION
## Summary

Addresses the Copilot review follow-ups from PR #14 around auth proxy safety and SSR helper cleanup.

## Changes

- Only honors Kitcn's `x-better-auth-forwarded-*` headers for OAuth proxy origin inference and validates the resulting origin against configured trusted origins before rewriting the Better Auth request URL.
- Makes loopback trusted host derivation explicit instead of relying on `URL` parse fallback for wildcard ports.
- Lazily reuses the TanStack Start Better Auth helper instance and removes broad `any` casts from the auth helper wrappers.
- Reuses `ConvexHttpClient` instances per request `QueryClient` and `convexUrl + token` pair for SSR loader queries, avoiding multiple client allocations during parallel loader prefetches without retaining token-keyed clients globally.
- Documents the client-side `ensureQueryData` path as relying on Kitcn's installed default `ConvexQueryClient.queryFn()`.

## Validation

- `pnpm test convex/lib/get-env.test.ts src/lib/convex/auth-server.test.ts`
- `pnpm run typecheck`
- `pnpm run build`
