### PR TITLE
Add landing homepage, dashboard page, and fix local auth

### DIFF
--- a/convex/functions/auth.ts
+++ b/convex/functions/auth.ts
@@ -129,11 +129,15 @@ export default defineAuth(() => {
         },
       }),
       forwardedAuthRequestPlugin(),
-      oAuthProxy({
-        ...(oauthProxyCurrentUrl ? { currentURL: oauthProxyCurrentUrl } : {}),
-        productionURL: oauthProxyProductionUrl,
-        secret: oauthProxySecret,
-      }),
+      ...(oauthProxySecret
+        ? [
+            oAuthProxy({
+              ...(oauthProxyCurrentUrl ? { currentURL: oauthProxyCurrentUrl } : {}),
+              productionURL: oauthProxyProductionUrl,
+              secret: oauthProxySecret,
+            }),
+          ]
+        : []),
       convex({
         authConfig,
         jwks,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as AtChar123orgChar125RouteRouteImport } from './routes/@{$org}/route'
 import { Route as IndexRouteImport } from './routes/index'
@@ -36,6 +37,11 @@ import { Route as AtChar123orgChar125ProjectFeedbackBoardsNewRouteImport } from 
 import { Route as AtChar123orgChar125ProjectFeedbackBoardsBoardIndexRouteImport } from './routes/@{$org}/$project/feedback/boards/$board/index'
 import { Route as AtChar123orgChar125ProjectFeedbackBoardsBoardEditRouteImport } from './routes/@{$org}/$project/feedback/boards/$board/edit'
 
+const DashboardRoute = DashboardRouteImport.update({
+  id: '/dashboard',
+  path: '/dashboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthRoute = AuthRouteImport.update({
   id: '/auth',
   path: '/auth',
@@ -192,6 +198,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/@{$org}': typeof AtChar123orgChar125RouteRouteWithChildren
   '/auth': typeof AuthRoute
+  '/dashboard': typeof DashboardRoute
   '/@{$org}/$project': typeof AtChar123orgChar125ProjectRouteRouteWithChildren
   '/@{$org}/': typeof AtChar123orgChar125IndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -219,6 +226,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
+  '/dashboard': typeof DashboardRoute
   '/@{$org}': typeof AtChar123orgChar125IndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/@{$org}/$project': typeof AtChar123orgChar125ProjectIndexRoute
@@ -247,6 +255,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/@{$org}': typeof AtChar123orgChar125RouteRouteWithChildren
   '/auth': typeof AuthRoute
+  '/dashboard': typeof DashboardRoute
   '/@{$org}/$project': typeof AtChar123orgChar125ProjectRouteRouteWithChildren
   '/@{$org}/': typeof AtChar123orgChar125IndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -277,6 +286,7 @@ export interface FileRouteTypes {
     | '/'
     | '/@{$org}'
     | '/auth'
+    | '/dashboard'
     | '/@{$org}/$project'
     | '/@{$org}/'
     | '/api/auth/$'
@@ -304,6 +314,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/auth'
+    | '/dashboard'
     | '/@{$org}'
     | '/api/auth/$'
     | '/@{$org}/$project'
@@ -331,6 +342,7 @@ export interface FileRouteTypes {
     | '/'
     | '/@{$org}'
     | '/auth'
+    | '/dashboard'
     | '/@{$org}/$project'
     | '/@{$org}/'
     | '/api/auth/$'
@@ -360,6 +372,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AtChar123orgChar125RouteRoute: typeof AtChar123orgChar125RouteRouteWithChildren
   AuthRoute: typeof AuthRoute
+  DashboardRoute: typeof DashboardRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   CreateTeamIndexRoute: typeof CreateTeamIndexRoute
   ProfileSettingsIndexRoute: typeof ProfileSettingsIndexRoute
@@ -367,6 +380,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/auth': {
       id: '/auth'
       path: '/auth'
@@ -637,6 +657,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AtChar123orgChar125RouteRoute: AtChar123orgChar125RouteRouteWithChildren,
   AuthRoute: AuthRoute,
+  DashboardRoute: DashboardRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   CreateTeamIndexRoute: CreateTeamIndexRoute,
   ProfileSettingsIndexRoute: ProfileSettingsIndexRoute,

--- a/src/routes/-auth.test.ts
+++ b/src/routes/-auth.test.ts
@@ -1,21 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest"
 
-import { getSafeRedirectTarget } from './auth';
+import { getSafeRedirectTarget } from "./auth"
 
-describe('getSafeRedirectTarget', () => {
-  it('defaults to the home page when redirect is missing', () => {
-    expect(getSafeRedirectTarget(undefined)).toBe('/');
-  });
+describe("getSafeRedirectTarget", () => {
+  it("defaults to the dashboard when redirect is missing", () => {
+    expect(getSafeRedirectTarget(undefined)).toBe("/dashboard")
+  })
 
-  it('avoids redirecting back to the auth page after login', () => {
-    expect(getSafeRedirectTarget('/auth')).toBe('/');
-    expect(getSafeRedirectTarget('/auth?redirect=%2Fauth')).toBe('/');
-  });
+  it("avoids redirecting back to the auth page after login", () => {
+    expect(getSafeRedirectTarget("/auth")).toBe("/dashboard")
+    expect(getSafeRedirectTarget("/auth?redirect=%2Fauth")).toBe("/dashboard")
+  })
 
-  it('preserves safe in-app redirect paths', () => {
-    expect(getSafeRedirectTarget('/acme')).toBe('/acme');
-    expect(getSafeRedirectTarget('/acme/project?tab=updates#latest')).toBe(
-      '/acme/project?tab=updates#latest'
-    );
-  });
-});
+  it("avoids redirecting back to the public landing page after login", () => {
+    expect(getSafeRedirectTarget("/")).toBe("/dashboard")
+  })
+
+  it("preserves safe in-app redirect paths", () => {
+    expect(getSafeRedirectTarget("/acme")).toBe("/acme")
+    expect(getSafeRedirectTarget("/acme/project?tab=updates#latest")).toBe(
+      "/acme/project?tab=updates#latest"
+    )
+  })
+})

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -15,14 +15,17 @@ export const Route = createFileRoute('/auth')({
 
 export function getSafeRedirectTarget(redirect: string | undefined) {
   if (!redirect) {
-    return '/';
+    return '/dashboard';
   }
 
   try {
     const resolved = new URL(redirect, 'https://usekino.com');
-    return resolved.pathname === '/auth' ? '/' : `${resolved.pathname}${resolved.search}${resolved.hash}`;
+    if (resolved.pathname === '/auth' || resolved.pathname === '/') {
+      return '/dashboard';
+    }
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
   } catch {
-    return '/';
+    return '/dashboard';
   }
 }
 

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react"
+import { Suspense, useState } from "react"
 import { useSuspenseQuery } from "@tanstack/react-query"
 import {
   Link,
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-router"
 import {
   ArrowRight,
+  ChevronDown,
   FolderOpen,
   Lock,
   Plus,
@@ -62,13 +63,15 @@ function AuthenticatedDashboard() {
   const orgs = orgsData?.teams ?? []
 
   return (
-    <div className="min-h-svh flex flex-col">
+    <div className="flex min-h-svh flex-col">
       {/* Minimal top bar */}
       <header className="border-b border-border/50 bg-absolute">
         <div className="container flex items-center justify-between py-3">
           <Link to="/dashboard" className="flex items-center gap-2.5">
             <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary">
-              <span className="text-xs font-bold text-primary-foreground">K</span>
+              <span className="text-xs font-bold text-primary-foreground">
+                K
+              </span>
             </div>
             <span className="text-sm font-semibold tracking-tight">Kino</span>
           </Link>
@@ -82,7 +85,7 @@ function AuthenticatedDashboard() {
             {user ? (
               <Link
                 to="/profile/settings"
-                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted transition-colors"
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-muted"
               >
                 <Avatar className="size-6 border">
                   <AvatarImage src={user.imageUrl} />
@@ -90,7 +93,7 @@ function AuthenticatedDashboard() {
                     {(user.name ?? user.username ?? "U")[0]?.toUpperCase()}
                   </AvatarFallback>
                 </Avatar>
-                <span className="hidden sm:inline text-sm text-muted-foreground">
+                <span className="hidden text-sm text-muted-foreground sm:inline">
                   {user.username ?? user.name}
                 </span>
               </Link>
@@ -104,9 +107,7 @@ function AuthenticatedDashboard() {
           {/* Page header */}
           <div className="flex items-end justify-between">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight">
-                Your teams
-              </h1>
+              <h1 className="text-2xl font-bold tracking-tight">Your teams</h1>
               <p className="mt-1 text-sm text-muted-foreground">
                 {orgs.length === 0
                   ? "You're not part of any teams yet."
@@ -161,6 +162,9 @@ function OrgSection({
 }: {
   org: { id: string; name: string; slug: string; logo?: string | null }
 }) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const projectsId = `org-projects-${org.slug}`
+
   return (
     <section>
       {/* Org header */}
@@ -176,12 +180,27 @@ function OrgSection({
               {org.name[0]?.toUpperCase()}
             </AvatarFallback>
           </Avatar>
-          <span className="font-semibold group-hover:underline decoration-2 underline-offset-2">
+          <span className="font-semibold decoration-2 underline-offset-2 group-hover:underline">
             {org.name}
           </span>
-          <ArrowRight className="size-3.5 text-muted-foreground opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+          <ArrowRight className="size-3.5 -translate-x-1 text-muted-foreground opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100" />
         </Link>
         <div className="flex items-center gap-1">
+          <Button
+            aria-controls={projectsId}
+            aria-expanded={isExpanded}
+            onClick={() => setIsExpanded((value) => !value)}
+            type="button"
+            variant="ghost"
+            size="sm"
+          >
+            Projects
+            <ChevronDown
+              className={`size-3.5 transition-transform ${
+                isExpanded ? "rotate-180" : ""
+              }`}
+            />
+          </Button>
           <Button asChild variant="ghost" size="sm">
             <Link to="/@{$org}/edit" params={{ org: org.slug }}>
               <Settings className="size-3.5" />
@@ -192,11 +211,13 @@ function OrgSection({
       </div>
 
       {/* Projects */}
-      <div className="mt-4">
-        <Suspense fallback={<ProjectsSkeleton />}>
-          <OrgProjectsList orgSlug={org.slug} />
-        </Suspense>
-      </div>
+      {isExpanded ? (
+        <div id={projectsId} className="mt-4">
+          <Suspense fallback={<ProjectsSkeleton />}>
+            <OrgProjectsList orgSlug={org.slug} />
+          </Suspense>
+        </div>
+      ) : null}
     </section>
   )
 }
@@ -234,15 +255,15 @@ function OrgProjectsList({ orgSlug }: { orgSlug: string }) {
           className="group rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/20 hover:bg-accent/30"
         >
           <div className="flex items-start justify-between">
-            <h4 className="text-sm font-medium group-hover:underline decoration-1 underline-offset-2">
+            <h4 className="text-sm font-medium decoration-1 underline-offset-2 group-hover:underline">
               {project.name}
             </h4>
             {project.visibility === "private" ? (
-              <Lock className="size-3 text-muted-foreground mt-0.5 shrink-0" />
+              <Lock className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
             ) : null}
           </div>
           {project.description ? (
-            <p className="mt-1.5 text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+            <p className="mt-1.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
               {project.description}
             </p>
           ) : (

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,0 +1,279 @@
+import { Suspense } from "react"
+import { useSuspenseQuery } from "@tanstack/react-query"
+import {
+  Link,
+  Navigate,
+  createFileRoute,
+  useRouterState,
+} from "@tanstack/react-router"
+import {
+  ArrowRight,
+  FolderOpen,
+  Lock,
+  Plus,
+  Settings,
+} from "lucide-react"
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useCRPC } from "@/lib/convex/crpc"
+import { crpcServer } from "@/lib/convex/crpc-server"
+
+export const Route = createFileRoute("/dashboard")({
+  loader: async ({ context }) => {
+    if (!context.loaderToken) {
+      return
+    }
+
+    await Promise.all([
+      context.queryClient.ensureQueryData(
+        crpcServer.profile.findMyProfile.queryOptions({})
+      ),
+      context.queryClient.ensureQueryData(
+        crpcServer.org.findMyOrgs.queryOptions({})
+      ),
+    ])
+  },
+  component: DashboardPage,
+})
+
+function DashboardPage() {
+  const { loaderToken } = Route.useRouteContext()
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  })
+
+  if (!loaderToken) {
+    return <Navigate search={{ redirect: pathname }} to="/auth" />
+  }
+
+  return <AuthenticatedDashboard />
+}
+
+function AuthenticatedDashboard() {
+  const crpc = useCRPC()
+  const { data: user } = useSuspenseQuery(
+    crpc.profile.findMyProfile.queryOptions({})
+  )
+  const { data: orgsData } = useSuspenseQuery(
+    crpc.org.findMyOrgs.queryOptions({})
+  )
+  const orgs = orgsData?.teams ?? []
+
+  return (
+    <div className="min-h-svh flex flex-col">
+      {/* Minimal top bar */}
+      <header className="border-b border-border/50 bg-absolute">
+        <div className="container flex items-center justify-between py-3">
+          <Link to="/dashboard" className="flex items-center gap-2.5">
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary">
+              <span className="text-xs font-bold text-primary-foreground">K</span>
+            </div>
+            <span className="text-sm font-semibold tracking-tight">Kino</span>
+          </Link>
+          <div className="flex items-center gap-3">
+            <Button asChild variant="ghost" size="sm">
+              <Link to="/create/team">
+                <Plus className="size-3.5" />
+                New team
+              </Link>
+            </Button>
+            {user ? (
+              <Link
+                to="/profile/settings"
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted transition-colors"
+              >
+                <Avatar className="size-6 border">
+                  <AvatarImage src={user.imageUrl} />
+                  <AvatarFallback className="text-xs">
+                    {(user.name ?? user.username ?? "U")[0]?.toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="hidden sm:inline text-sm text-muted-foreground">
+                  {user.username ?? user.name}
+                </span>
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <div className="container py-10 md:py-14">
+          {/* Page header */}
+          <div className="flex items-end justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">
+                Your teams
+              </h1>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {orgs.length === 0
+                  ? "You're not part of any teams yet."
+                  : `${orgs.length} team${orgs.length === 1 ? "" : "s"}`}
+              </p>
+            </div>
+            {orgsData?.underLimit ? (
+              <Button asChild size="sm">
+                <Link to="/create/team">
+                  <Plus className="size-3.5" />
+                  New team
+                </Link>
+              </Button>
+            ) : null}
+          </div>
+
+          {/* Org list */}
+          {orgs.length === 0 ? (
+            <div className="mt-12 rounded-lg border border-dashed border-border p-12 text-center">
+              <FolderOpen className="mx-auto size-8 text-muted-foreground/60" />
+              <h3 className="mt-4 text-sm font-medium">No teams yet</h3>
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                Create a team to start organizing your projects.
+              </p>
+              <div className="mt-5">
+                <Button asChild size="sm">
+                  <Link to="/create/team">Create a team</Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-8 space-y-10">
+              {orgs.map((org) => (
+                <OrgSection key={org.id} org={org} />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <footer className="mt-auto border-t border-border py-4 text-center text-sm text-muted-foreground">
+        <div className="container">
+          <p>&copy; {new Date().getFullYear()} Kino</p>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function OrgSection({
+  org,
+}: {
+  org: { id: string; name: string; slug: string; logo?: string | null }
+}) {
+  return (
+    <section>
+      {/* Org header */}
+      <div className="flex items-center justify-between">
+        <Link
+          to="/@{$org}"
+          params={{ org: org.slug }}
+          className="group flex items-center gap-3"
+        >
+          <Avatar className="size-8 border">
+            {org.logo ? <AvatarImage src={org.logo} /> : null}
+            <AvatarFallback className="text-sm font-semibold">
+              {org.name[0]?.toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <span className="font-semibold group-hover:underline decoration-2 underline-offset-2">
+            {org.name}
+          </span>
+          <ArrowRight className="size-3.5 text-muted-foreground opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+        </Link>
+        <div className="flex items-center gap-1">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/@{$org}/edit" params={{ org: org.slug }}>
+              <Settings className="size-3.5" />
+              <span className="sr-only sm:not-sr-only">Settings</span>
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Projects */}
+      <div className="mt-4">
+        <Suspense fallback={<ProjectsSkeleton />}>
+          <OrgProjectsList orgSlug={org.slug} />
+        </Suspense>
+      </div>
+    </section>
+  )
+}
+
+function OrgProjectsList({ orgSlug }: { orgSlug: string }) {
+  const crpc = useCRPC()
+  const { data: projects } = useSuspenseQuery(
+    crpc.project.getManyByOrg.queryOptions({
+      limit: 24,
+      orgSlug,
+    })
+  )
+
+  if (!projects || projects.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-6 py-8 text-center">
+        <p className="text-sm text-muted-foreground">No projects yet</p>
+        <Button asChild variant="ghost" size="sm" className="mt-2">
+          <Link to="/@{$org}/create-project" params={{ org: orgSlug }}>
+            <Plus className="size-3.5" />
+            Create project
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {projects.map((project) => (
+        <Link
+          key={project.id}
+          to="/@{$org}/$project"
+          params={{ org: orgSlug, project: project.slug }}
+          className="group rounded-lg border border-border bg-card p-4 transition-colors hover:border-foreground/20 hover:bg-accent/30"
+        >
+          <div className="flex items-start justify-between">
+            <h4 className="text-sm font-medium group-hover:underline decoration-1 underline-offset-2">
+              {project.name}
+            </h4>
+            {project.visibility === "private" ? (
+              <Lock className="size-3 text-muted-foreground mt-0.5 shrink-0" />
+            ) : null}
+          </div>
+          {project.description ? (
+            <p className="mt-1.5 text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+              {project.description}
+            </p>
+          ) : (
+            <p className="mt-1.5 text-xs text-muted-foreground/60 italic">
+              No description
+            </p>
+          )}
+        </Link>
+      ))}
+      <Link
+        to="/@{$org}/create-project"
+        params={{ org: orgSlug }}
+        className="flex items-center justify-center rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground transition-colors hover:border-foreground/20 hover:bg-accent/30 hover:text-foreground"
+      >
+        <Plus className="mr-1.5 size-3.5" />
+        New project
+      </Link>
+    </div>
+  )
+}
+
+function ProjectsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="rounded-lg border border-border p-4">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="mt-3 h-3 w-full" />
+          <Skeleton className="mt-1.5 h-3 w-2/3" />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,11 @@
+import type { ReactNode } from "react"
 import { Link, Navigate, createFileRoute } from "@tanstack/react-router"
-import { ArrowRight, MessageSquare, Newspaper, Route as RouteIcon } from "lucide-react"
+import {
+  ArrowRight,
+  MessageSquare,
+  Newspaper,
+  Route as RouteIcon,
+} from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 
@@ -19,13 +25,15 @@ function IndexPage() {
 
 function LandingPage() {
   return (
-    <div className="min-h-svh flex flex-col">
+    <div className="flex min-h-svh flex-col">
       {/* Nav */}
       <header className="border-b border-border/50">
         <div className="container flex items-center justify-between py-4">
           <div className="flex items-center gap-2.5">
             <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary">
-              <span className="text-xs font-bold text-primary-foreground">K</span>
+              <span className="text-xs font-bold text-primary-foreground">
+                K
+              </span>
             </div>
             <span className="text-sm font-semibold tracking-tight">Kino</span>
           </div>
@@ -44,13 +52,15 @@ function LandingPage() {
       <main className="flex-1">
         <section className="container py-24 md:py-32">
           <div className="max-w-2xl">
-            <p className="text-sm font-medium text-muted-foreground">Open-source project toolkit</p>
+            <p className="text-sm font-medium text-muted-foreground">
+              Open-source project toolkit
+            </p>
             <h1 className="mt-3 text-4xl font-bold tracking-tight md:text-5xl">
               Ship products with your team, not around them.
             </h1>
-            <p className="mt-4 text-lg text-muted-foreground leading-relaxed max-w-xl">
-              Feedback boards, roadmaps, and changelogs — in one place.
-              Give your users a seat at the table without losing focus.
+            <p className="mt-4 max-w-xl text-lg leading-relaxed text-muted-foreground">
+              Feedback boards, roadmaps, and changelogs — in one place. Give
+              your users a seat at the table without losing focus.
             </p>
             <div className="mt-8 flex items-center gap-3">
               <Button asChild>
@@ -60,8 +70,17 @@ function LandingPage() {
                 </Link>
               </Button>
               <Button asChild variant="outline">
-                <a href="https://github.com" target="_blank" rel="noopener noreferrer">
-                  <svg viewBox="0 0 16 16" fill="currentColor" className="size-4" aria-hidden="true">
+                <a
+                  href="https://github.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    fill="currentColor"
+                    className="size-4"
+                    aria-hidden="true"
+                  >
                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
                   </svg>
                   View source
@@ -96,7 +115,7 @@ function LandingPage() {
 
         {/* CTA */}
         <section className="border-t border-border/50">
-          <div className="container py-20 md:py-24 text-center">
+          <div className="container py-20 text-center md:py-24">
             <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
               Ready to get started?
             </h2>
@@ -120,7 +139,12 @@ function LandingPage() {
         <div className="container flex items-center justify-between text-sm text-muted-foreground">
           <p>&copy; {new Date().getFullYear()} Kino</p>
           <div className="flex items-center gap-4">
-            <a href="https://github.com" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">
+            <a
+              href="https://github.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-foreground"
+            >
               GitHub
             </a>
           </div>
@@ -135,17 +159,19 @@ function FeatureCell({
   title,
   description,
 }: {
-  icon: React.ReactNode
+  icon: ReactNode
   title: string
   description: string
 }) {
   return (
-    <div className="bg-card p-8 md:p-10 first:rounded-t-lg md:first:rounded-tl-lg md:first:rounded-tr-none last:rounded-b-lg md:last:rounded-br-lg md:last:rounded-bl-none [&:nth-child(3)]:md:rounded-tr-lg [&:nth-child(1)]:md:rounded-bl-lg">
+    <div className="bg-card p-8 first:rounded-t-lg last:rounded-b-lg md:p-10 md:first:rounded-tl-lg md:first:rounded-tr-none md:last:rounded-br-lg md:last:rounded-bl-none [&:nth-child(1)]:md:rounded-bl-lg [&:nth-child(3)]:md:rounded-tr-lg">
       <div className="flex items-center gap-2.5 text-foreground">
         {icon}
         <h3 className="font-semibold">{title}</h3>
       </div>
-      <p className="mt-3 text-sm text-muted-foreground leading-relaxed">{description}</p>
+      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+        {description}
+      </p>
     </div>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,75 +1,151 @@
-import { useSuspenseQuery } from "@tanstack/react-query"
-import {
-  Link,
-  Navigate,
-  createFileRoute,
-  useRouterState,
-} from "@tanstack/react-router"
+import { Link, Navigate, createFileRoute } from "@tanstack/react-router"
+import { ArrowRight, MessageSquare, Newspaper, Route as RouteIcon } from "lucide-react"
 
-import { useCRPC } from "@/lib/convex/crpc"
-import { crpcServer } from "@/lib/convex/crpc-server"
+import { Button } from "@/components/ui/button"
 
 export const Route = createFileRoute("/")({
-  loader: async ({ context }) => {
-    if (!context.loaderToken) {
-      return
-    }
-
-    await Promise.all([
-      context.queryClient.ensureQueryData(
-        crpcServer.profile.findMyProfile.queryOptions({})
-      ),
-      context.queryClient.ensureQueryData(
-        crpcServer.org.findMyOrgs.queryOptions({})
-      ),
-    ])
-  },
   component: IndexPage,
 })
 
 function IndexPage() {
   const { loaderToken } = Route.useRouteContext()
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
-  })
 
-  if (!loaderToken) {
-    return <Navigate search={{ redirect: pathname }} to="/auth" />
+  if (loaderToken) {
+    return <Navigate to="/dashboard" />
   }
 
-  return <AuthenticatedIndexPage />
+  return <LandingPage />
 }
 
-function AuthenticatedIndexPage() {
-  const crpc = useCRPC()
-  const { data: user } = useSuspenseQuery(
-    crpc.profile.findMyProfile.queryOptions({})
-  )
-  const { data: orgsData } = useSuspenseQuery(
-    crpc.org.findMyOrgs.queryOptions({})
-  )
-  const orgs = orgsData?.teams
-
+function LandingPage() {
   return (
-    <div>
-      <h1>Hello, {user?.name}</h1>
-      <div>Below are a list of teams you are a part of.</div>
-      {!orgs?.length ? (
-        <div>No orgs found.</div>
-      ) : (
-        orgs.map((org) => {
-          return (
-            <Link
-              key={org.id}
-              className="link-text block"
-              params={{ org: org.slug }}
-              to="/@{$org}"
-            >
-              {org.name}
-            </Link>
-          )
-        })
-      )}
+    <div className="min-h-svh flex flex-col">
+      {/* Nav */}
+      <header className="border-b border-border/50">
+        <div className="container flex items-center justify-between py-4">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary">
+              <span className="text-xs font-bold text-primary-foreground">K</span>
+            </div>
+            <span className="text-sm font-semibold tracking-tight">Kino</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button asChild variant="ghost" size="sm">
+              <Link to="/auth">Sign in</Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link to="/auth">Get started</Link>
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <main className="flex-1">
+        <section className="container py-24 md:py-32">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium text-muted-foreground">Open-source project toolkit</p>
+            <h1 className="mt-3 text-4xl font-bold tracking-tight md:text-5xl">
+              Ship products with your team, not around them.
+            </h1>
+            <p className="mt-4 text-lg text-muted-foreground leading-relaxed max-w-xl">
+              Feedback boards, roadmaps, and changelogs — in one place.
+              Give your users a seat at the table without losing focus.
+            </p>
+            <div className="mt-8 flex items-center gap-3">
+              <Button asChild>
+                <Link to="/auth">
+                  Start for free
+                  <ArrowRight />
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <a href="https://github.com" target="_blank" rel="noopener noreferrer">
+                  <svg viewBox="0 0 16 16" fill="currentColor" className="size-4" aria-hidden="true">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                  </svg>
+                  View source
+                </a>
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        {/* Feature cards */}
+        <section className="border-t border-border/50">
+          <div className="container py-20 md:py-24">
+            <div className="grid gap-px rounded-lg border border-border bg-border md:grid-cols-3">
+              <FeatureCell
+                icon={<MessageSquare className="size-5" />}
+                title="Feedback"
+                description="Collect bugs, feature requests, and ideas. Let users upvote so you know what matters."
+              />
+              <FeatureCell
+                icon={<RouteIcon className="size-5" />}
+                title="Roadmap"
+                description="Share what you're working on. Move items through statuses as you build."
+              />
+              <FeatureCell
+                icon={<Newspaper className="size-5" />}
+                title="Updates"
+                description="Write changelogs and announcements. Keep your users informed without the noise."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="border-t border-border/50">
+          <div className="container py-20 md:py-24 text-center">
+            <h2 className="text-2xl font-bold tracking-tight md:text-3xl">
+              Ready to get started?
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              Free for small teams. Set up in under a minute.
+            </p>
+            <div className="mt-6">
+              <Button asChild>
+                <Link to="/auth">
+                  Create your first project
+                  <ArrowRight />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-border py-6">
+        <div className="container flex items-center justify-between text-sm text-muted-foreground">
+          <p>&copy; {new Date().getFullYear()} Kino</p>
+          <div className="flex items-center gap-4">
+            <a href="https://github.com" target="_blank" rel="noopener noreferrer" className="hover:text-foreground transition-colors">
+              GitHub
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function FeatureCell({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode
+  title: string
+  description: string
+}) {
+  return (
+    <div className="bg-card p-8 md:p-10 first:rounded-t-lg md:first:rounded-tl-lg md:first:rounded-tr-none last:rounded-b-lg md:last:rounded-br-lg md:last:rounded-bl-none [&:nth-child(3)]:md:rounded-tr-lg [&:nth-child(1)]:md:rounded-bl-lg">
+      <div className="flex items-center gap-2.5 text-foreground">
+        {icon}
+        <h3 className="font-semibold">{title}</h3>
+      </div>
+      <p className="mt-3 text-sm text-muted-foreground leading-relaxed">{description}</p>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Public landing page at `/`** — unauthenticated users see a marketing page instead of being redirected to `/auth`. Authenticated users are silently redirected to `/dashboard`.
- **New `/dashboard` route** — lists the user's teams with their projects in a responsive card grid. Includes empty states, loading skeletons, and quick-create links.
- **Auth redirect fix** — post-login redirect now targets `/dashboard` instead of `/`.
- **Conditional OAuth proxy** — `oAuthProxy` plugin only registers when `OAUTH_PROXY_SECRET` is set, fixing the broken GitHub OAuth flow in local dev where the proxy was active with no secret configured.

## Test plan

- [ ] Visit `/` while signed out → see landing page, no redirect
- [ ] Visit `/` while signed in → redirect to `/dashboard`
- [ ] Visit `/dashboard` while signed out → redirect to `/auth`
- [ ] Sign in with GitHub → land on `/dashboard` with teams and projects listed
- [ ] Verify OAuth proxy still works in production (where `OAUTH_PROXY_SECRET` is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)