### PR TITLE
Fix sidebar border not extending full page height

### DIFF
--- a/src/components/route-pending.tsx
+++ b/src/components/route-pending.tsx
@@ -5,8 +5,8 @@ type RoutePendingProps = {
 export function RoutePending({ variant = 'page' }: RoutePendingProps) {
 	if (variant === 'sidebar') {
 		return (
-			<div className='container py-8'>
-				<div className='grid grid-cols-1 gap-8 md:grid-cols-12'>
+			<div className='container flex flex-1 flex-col py-8'>
+				<div className='grid flex-1 grid-cols-1 gap-8 md:grid-cols-12'>
 					<div className='order-first space-y-4 md:order-last md:col-span-3'>
 						<div className='h-10 w-full animate-pulse rounded bg-muted' />
 						<div className='h-48 w-full animate-pulse rounded bg-muted' />
@@ -24,8 +24,8 @@ export function RoutePending({ variant = 'page' }: RoutePendingProps) {
 
 	if (variant === 'detail') {
 		return (
-			<div className='container py-8'>
-				<div className='grid grid-cols-1 gap-8 md:grid-cols-12'>
+			<div className='container flex flex-1 flex-col py-8'>
+				<div className='grid flex-1 grid-cols-1 gap-8 md:grid-cols-12'>
 					<div className='order-first space-y-6 border-l border-border/75 py-6 pl-8 md:order-last md:col-span-4'>
 						<div className='h-10 w-full animate-pulse rounded bg-muted' />
 						<div className='h-32 w-full animate-pulse rounded bg-muted' />

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -286,7 +286,7 @@ function FeedbackDetailRoute() {
   )
 
   return (
-    <div className="container h-full grid-cols-12 gap-8 md:grid">
+    <div className="container flex-1 grid-cols-12 gap-8 md:grid">
       <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
         <div className="sticky top-4 flex flex-col gap-6 pl-8">
           <div>

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -241,8 +241,8 @@ function FeedbackListRoute() {
   }
 
   return (
-    <div className="container h-full overflow-visible">
-      <div className="h-full grid-cols-12 gap-8 md:grid">
+    <div className="container flex flex-1 flex-col overflow-visible">
+      <div className="flex-1 grid-cols-12 gap-8 md:grid">
         <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-3">
           <div className="sticky top-6 flex flex-col overflow-hidden">
             <div className="border-b pb-6 pl-6">

--- a/src/routes/@{$org}/$project/updates/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/index.tsx
@@ -224,7 +224,7 @@ function UpdateDetailRoute() {
   }
 
   return (
-    <div className="container h-full grid-cols-12 gap-8 md:grid">
+    <div className="container flex-1 grid-cols-12 gap-8 md:grid">
       <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
         <div className="sticky top-4 flex flex-col gap-6 pl-8">
           <style>{heartPopKeyframes}</style>

--- a/src/routes/@{$org}/$project/updates/index.tsx
+++ b/src/routes/@{$org}/$project/updates/index.tsx
@@ -94,8 +94,8 @@ function UpdatesListRoute() {
     : allUpdates
 
   return (
-    <div className="container h-full overflow-visible">
-      <div className="h-full grid-cols-12 gap-8 md:grid">
+    <div className="container flex flex-1 flex-col overflow-visible">
+      <div className="flex-1 grid-cols-12 gap-8 md:grid">
         <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-3">
           <div className="sticky top-6 flex flex-col overflow-hidden">
             {canEdit ? (

--- a/src/routes/@{$org}/create-project/index.tsx
+++ b/src/routes/@{$org}/create-project/index.tsx
@@ -89,7 +89,7 @@ function CreateProjectRoute() {
   return (
     <div className="flex flex-auto flex-col">
       <div className="container flex flex-auto flex-col">
-        <div className="grid h-full grid-cols-12">
+        <div className="grid flex-1 grid-cols-12">
           <div className="col-span-3 border-r">
             <form.Subscribe selector={(state) => state.values}>
               {(values) => (


### PR DESCRIPTION
## Summary
- Replace `h-full` with `flex-1` on sidebar grid containers so they participate in the parent flex layout and stretch to fill remaining viewport space
- Fixes the sidebar `border-l` stopping where content ends instead of extending to the footer
- Applies consistently to feedback list/detail, updates list/detail, create-project, and loading skeletons (6 files)

## Test plan
- [ ] Visit feedback list page with few/no items — sidebar border should extend to footer
- [ ] Visit updates list page — same behavior
- [ ] Visit a feedback detail page — sidebar border extends full height
- [ ] Visit an update detail page — sidebar border extends full height
- [ ] Visit create project page — preview panel border extends full height
- [ ] Resize browser window to confirm responsive behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)