### PR TITLE
[codex] Tweak homepage CTA copy

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -120,7 +120,7 @@ function LandingPage() {
               Ready to get started?
             </h2>
             <p className="mt-3 text-muted-foreground">
-              Free for small teams. Set up in under a minute.
+              Free for small teams. Set up in under a minute and start collecting feedback fast.
             </p>
             <div className="mt-6">
               <Button asChild>


### PR DESCRIPTION
## What changed

Updated the home page CTA copy to read a little more clearly on the landing page.

## Why

This is a deliberately small UI change so we can exercise the full preview deployment and auth flow after the recent auth changes.

## Impact

The only user-facing change is the final CTA sentence on the `/` route.

## Validation

- `pnpm run typecheck`
