### PR TITLE
[codex] Fix dashboard auth hydration

### DIFF
--- a/src/lib/convex/convex-provider.tsx
+++ b/src/lib/convex/convex-provider.tsx
@@ -2,8 +2,8 @@
 
 import { useQueryClient } from "@tanstack/react-query"
 import { ConvexAuthProvider } from "kitcn/auth/client"
-import { type ConvexQueryClient, useAuthStore, useAuthValue } from "kitcn/react"
-import { useEffect, useRef } from "react"
+import { type ConvexQueryClient, useAuthStore } from "kitcn/react"
+import { useEffect } from "react"
 import type { ReactNode } from "react"
 
 import { authClient } from "@/lib/convex/auth-client"
@@ -24,47 +24,11 @@ export function AppConvexProvider({
       client={convexQueryClient.convexClient}
       initialToken={initialToken ?? undefined}
     >
-      <InitialAuthStoreBootstrap initialToken={initialToken}>
-        <QueryProvider convexQueryClient={convexQueryClient}>
-          {children}
-        </QueryProvider>
-      </InitialAuthStoreBootstrap>
+      <QueryProvider convexQueryClient={convexQueryClient}>
+        {children}
+      </QueryProvider>
     </ConvexAuthProvider>
   )
-}
-
-function InitialAuthStoreBootstrap({
-  children,
-  initialToken,
-}: {
-  children: ReactNode
-  initialToken?: string | null
-}) {
-  const authStore = useAuthStore()
-  const didBootstrapRef = useRef(false)
-  const token = useAuthValue("token")
-  const isAuthenticated = useAuthValue("isAuthenticated")
-  const isLoading = useAuthValue("isLoading")
-
-  if (!didBootstrapRef.current) {
-    didBootstrapRef.current = true
-
-    if (initialToken) {
-      authStore.set("token", initialToken)
-      authStore.set("expiresAt", decodeJwtExp(initialToken))
-      authStore.set("isAuthenticated", true)
-      authStore.set("isLoading", false)
-      authStore.set("sessionSyncGraceUntil", null)
-    }
-  }
-
-  if (initialToken && token && isLoading && !isAuthenticated) {
-    // Keep SSR-hydrated auth-bound queries stable while Better Auth session
-    // state catches up to the server-provided Convex token.
-    authStore.set("isAuthenticated", true)
-  }
-
-  return children
 }
 
 function QueryProvider({

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -143,9 +143,12 @@ export const Route = createFileRoute("/@{$org}/$project/feedback/$slug/")({
       ),
       projectData.permissions.canEdit
         ? context.queryClient.ensureQueryData(
-            crpcServer.projectMember.listAssignableMembers.queryOptions({
-              projectId: projectData.project.id,
-            })
+            crpcServer.projectMember.listAssignableMembers.queryOptions(
+              {
+                projectId: projectData.project.id,
+              },
+              { skipUnauth: true }
+            )
           )
         : Promise.resolve(null),
     ])
@@ -206,7 +209,7 @@ function FeedbackDetailRoute() {
       {
         projectId: projectData.project.id,
       },
-      { enabled: !!projectData.permissions.canEdit }
+      { enabled: !!projectData.permissions.canEdit, skipUnauth: true }
     )
   )
 

--- a/src/routes/@{$org}/create-project/index.tsx
+++ b/src/routes/@{$org}/create-project/index.tsx
@@ -35,7 +35,7 @@ function CreateProjectRoute() {
   const limitsQuery = useQuery(
     crpc.org.getMyPermission.queryOptions(
       { slug: params.org },
-      { enabled: !!orgQuery.data?.permissions.canCreate }
+      { enabled: !!orgQuery.data?.permissions.canCreate, skipUnauth: true }
     )
   );
 

--- a/src/routes/@{$org}/index.tsx
+++ b/src/routes/@{$org}/index.tsx
@@ -33,7 +33,10 @@ export const Route = createFileRoute("/@{$org}/")({
 
     if (orgData?.permissions.canCreate) {
       await context.queryClient.ensureQueryData(
-        crpcServer.org.getMyPermission.queryOptions({ slug: params.org })
+        crpcServer.org.getMyPermission.queryOptions(
+          { slug: params.org },
+          { skipUnauth: true }
+        )
       )
     }
   },
@@ -57,7 +60,7 @@ function OrganizationRoute() {
   const limitsQuery = useQuery(
     crpc.org.getMyPermission.queryOptions(
       { slug: params.org },
-      { enabled: !!orgData?.permissions.canCreate }
+      { enabled: !!orgData?.permissions.canCreate, skipUnauth: true }
     )
   )
   const projects = projectsData ?? []

--- a/src/routes/create/team/index.tsx
+++ b/src/routes/create/team/index.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute("/create/team/")({
     }
 
     await context.queryClient.ensureQueryData(
-      crpcServer.org.findMyOrgs.queryOptions({})
+      crpcServer.org.findMyOrgs.queryOptions({}, { skipUnauth: true })
     )
   },
   component: CreateTeamRoute,
@@ -53,7 +53,7 @@ function AuthenticatedCreateTeamRoute() {
   const crpc = useCRPC()
   const [formError, setFormError] = useState<string>()
   const { data: orgsData } = useSuspenseQuery(
-    crpc.org.findMyOrgs.queryOptions({})
+    crpc.org.findMyOrgs.queryOptions({}, { skipUnauth: true })
   )
   const createMutation = useMutation(
     crpc.org.create.mutationOptions({

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -29,10 +29,10 @@ export const Route = createFileRoute("/dashboard")({
 
     await Promise.all([
       context.queryClient.ensureQueryData(
-        crpcServer.profile.findMyProfile.queryOptions({})
+        crpcServer.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
       ),
       context.queryClient.ensureQueryData(
-        crpcServer.org.findMyOrgs.queryOptions({})
+        crpcServer.org.findMyOrgs.queryOptions({}, { skipUnauth: true })
       ),
     ])
   },
@@ -55,10 +55,10 @@ function DashboardPage() {
 function AuthenticatedDashboard() {
   const crpc = useCRPC()
   const { data: user } = useSuspenseQuery(
-    crpc.profile.findMyProfile.queryOptions({})
+    crpc.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
   )
   const { data: orgsData } = useSuspenseQuery(
-    crpc.org.findMyOrgs.queryOptions({})
+    crpc.org.findMyOrgs.queryOptions({}, { skipUnauth: true })
   )
   const orgs = orgsData?.teams ?? []
 

--- a/src/routes/profile/settings/index.tsx
+++ b/src/routes/profile/settings/index.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/profile/settings/")({
     }
 
     await context.queryClient.ensureQueryData(
-      crpcServer.profile.findMyProfile.queryOptions({})
+      crpcServer.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
     )
   },
   component: ProfileSettingsRoute,
@@ -53,7 +53,7 @@ function AuthenticatedProfileSettingsRoute() {
   const updateMutation = useMutation(crpc.profile.update.mutationOptions())
   const [formError, setFormError] = useState<string | null>(null)
   const profileQuery = useSuspenseQuery(
-    crpc.profile.findMyProfile.queryOptions({})
+    crpc.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
   )
   const profile = profileQuery.data
 


### PR DESCRIPTION
## Summary

- Remove the custom render-time auth store bootstrap that forced client auth to look settled before Convex auth finished syncing.
- Keep SSR auth and route prefetch intact via the root loader token.
- Make auth-required frontend reads use `skipUnauth` where a transient client-side token gap should not trip the TanStack error boundary.
- Audited the app for auth-required cRPC queries and covered the remaining call sites for `profile.findMyProfile`, `org.findMyOrgs`, `org.getMyPermission`, and `projectMember.listAssignableMembers`.

## Root cause

Several protected routes SSR-prefetch auth-required Convex data successfully when a loader token is present. During client hydration, the previous local bootstrap manually set `isLoading=false` and `isAuthenticated=true` from the SSR token before kitcn/Convex auth had fully synced. That could allow auth-required subscriptions to start while the Convex client still lacked usable auth, causing intermittent unauthorized failures on first navigation.

## Validation

- `pnpm test src/routes/-auth.test.ts src/lib/convex/auth-server.test.ts convex/functions/auth.test.ts convex/lib/get-env.test.ts`
- `pnpm run typecheck`
- `pnpm run build`