### PR TITLE
[codex] Polish markdown editor rendering and toolbar state

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@base-ui/react": "^1.4.1",
     "@convex-dev/r2": "^0.10.1",
     "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
@@ -1258,6 +1261,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/geist-mono@5.2.8':
+    resolution: {integrity: sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==}
 
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
@@ -6441,6 +6447,8 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/geist-mono@5.2.8': {}
 
   '@fontsource-variable/geist@5.2.8': {}
 

--- a/src/components/editor/editor-content-display.tsx
+++ b/src/components/editor/editor-content-display.tsx
@@ -1,36 +1,66 @@
-import { useMemo } from 'react';
+import { startTransition, useEffect, useMemo, useState } from "react"
 
-import { cn } from '@/lib/utils';
+import { cn } from "@/lib/utils"
 
-import { sanitizeEditorContent } from './sanitize-content';
+import { sanitizeEditorContent } from "./sanitize-content"
 
 type EditorContentDisplayProps = {
-  className?: string;
-  content: string;
-};
+  className?: string
+  content: string
+}
 
-export function EditorContentDisplay({ className, content }: EditorContentDisplayProps) {
-  const isHTML = content.startsWith('<') && content.includes('</');
-  const processedContent = useMemo(() => (isHTML ? sanitizeEditorContent(content) : content), [content, isHTML]);
+export function EditorContentDisplay({
+  className,
+  content,
+}: EditorContentDisplayProps) {
+  const isHTML = content.startsWith("<") && content.includes("</")
+  const baseContent = useMemo(
+    () => (isHTML ? sanitizeEditorContent(content) : content),
+    [content, isHTML]
+  )
+  const [processedContent, setProcessedContent] = useState(baseContent)
+
+  useEffect(() => {
+    let isCancelled = false
+
+    if (!isHTML) {
+      setProcessedContent(content)
+      return () => {
+        isCancelled = true
+      }
+    }
+
+    setProcessedContent(baseContent)
+
+    if (!baseContent.includes("<pre") || !baseContent.includes("<code")) {
+      return () => {
+        isCancelled = true
+      }
+    }
+
+    void import("./format-content-for-display").then(
+      ({ formatContentForDisplay }) => {
+        if (isCancelled) return
+
+        startTransition(() => {
+          setProcessedContent(formatContentForDisplay(baseContent))
+        })
+      }
+    )
+
+    return () => {
+      isCancelled = true
+    }
+  }, [baseContent, content, isHTML])
 
   if (!isHTML) {
-    return <div className={cn('whitespace-pre-wrap', className)}>{content}</div>;
+    return <div className={cn("whitespace-pre-wrap", className)}>{content}</div>
   }
 
   return (
     <div
-      className={cn(
-        'prose max-w-none pb-1 text-foreground dark:prose-invert',
-        'prose-headings:font-semibold',
-        'prose-h4:text-[1.1rem] prose-h5:text-[1rem] prose-h6:text-[0.95rem]',
-        'prose-a:text-primary prose-a:no-underline hover:prose-a:underline',
-        'prose-code:before:content-none prose-code:after:content-none',
-        'prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:pl-4 prose-blockquote:text-muted-foreground prose-blockquote:not-italic prose-blockquote:before:content-none prose-blockquote:after:content-none',
-        '[&>blockquote:first-child>*:first-child]:mt-0',
-        'prose-ol:my-1.5 prose-ul:my-1.5 prose-li:my-0 prose-li:leading-snug',
-        className
-      )}
+      className={cn("markdown-prose pb-1", className)}
       dangerouslySetInnerHTML={{ __html: processedContent }}
     />
-  );
+  )
 }

--- a/src/components/editor/editor-content-display.tsx
+++ b/src/components/editor/editor-content-display.tsx
@@ -2,6 +2,7 @@ import { startTransition, useEffect, useMemo, useState } from "react"
 
 import { cn } from "@/lib/utils"
 
+import { formatInlineCode } from "./format-inline-code"
 import { sanitizeEditorContent } from "./sanitize-content"
 
 type EditorContentDisplayProps = {
@@ -18,7 +19,15 @@ export function EditorContentDisplay({
     () => (isHTML ? sanitizeEditorContent(content) : content),
     [content, isHTML]
   )
-  const [processedContent, setProcessedContent] = useState(baseContent)
+  const hasCodeBlock =
+    baseContent.includes("<pre") && baseContent.includes("<code")
+  const hasInlineBackticks = baseContent.includes("`")
+  const immediateContent = useMemo(() => {
+    if (!isHTML) return content
+    if (hasCodeBlock) return baseContent
+    return hasInlineBackticks ? formatInlineCode(baseContent) : baseContent
+  }, [baseContent, content, hasCodeBlock, hasInlineBackticks, isHTML])
+  const [processedContent, setProcessedContent] = useState(immediateContent)
 
   useEffect(() => {
     let isCancelled = false
@@ -30,9 +39,9 @@ export function EditorContentDisplay({
       }
     }
 
-    setProcessedContent(baseContent)
+    setProcessedContent(immediateContent)
 
-    if (!baseContent.includes("<pre") || !baseContent.includes("<code")) {
+    if (!hasCodeBlock) {
       return () => {
         isCancelled = true
       }
@@ -51,7 +60,7 @@ export function EditorContentDisplay({
     return () => {
       isCancelled = true
     }
-  }, [baseContent, content, isHTML])
+  }, [baseContent, hasCodeBlock, immediateContent, isHTML])
 
   if (!isHTML) {
     return <div className={cn("whitespace-pre-wrap", className)}>{content}</div>

--- a/src/components/editor/editor-toolbar.tsx
+++ b/src/components/editor/editor-toolbar.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { Editor } from '@tiptap/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { Editor } from "@tiptap/react"
 import {
   Bold,
+  Check,
   Code,
   Code2,
   Heading,
@@ -13,147 +14,356 @@ import {
   Quote,
   Strikethrough,
   Underline,
-} from 'lucide-react';
+} from "lucide-react"
 
-import { Button } from '@/components/ui/button';
+import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { cn } from '@/lib/utils';
+} from "@/components/ui/dropdown-menu"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
 
 type ToolbarItem = {
-  action: () => void;
-  group: number;
-  icon: React.ReactNode;
-  id: string;
-  isActive?: () => boolean;
-  label: string;
-};
+  action: () => void
+  group: number
+  icon: React.ReactNode
+  id: string
+  isActive?: () => boolean
+  label: string
+  width?: number
+}
 
 export function EditorToolbar({ editor }: { editor: Editor | null }) {
-  const toolbarRef = useRef<HTMLDivElement>(null);
-  const [overflowItems, setOverflowItems] = useState<ToolbarItem[]>([]);
-  const [visibleItems, setVisibleItems] = useState<ToolbarItem[]>([]);
-  const [linkUrl, setLinkUrl] = useState('');
-  const [linkPopoverOpen, setLinkPopoverOpen] = useState(false);
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const [overflowItems, setOverflowItems] = useState<ToolbarItem[]>([])
+  const [visibleItems, setVisibleItems] = useState<ToolbarItem[]>([])
+  const [linkUrl, setLinkUrl] = useState("")
+  const [linkPopoverOpen, setLinkPopoverOpen] = useState(false)
+  const [, setEditorStateVersion] = useState(0)
+  const toggleButtonIds = new Set([
+    "bold",
+    "italic",
+    "underline",
+    "strike",
+    "code",
+    "codeBlock",
+    "blockquote",
+    "bulletList",
+    "orderedList",
+  ])
 
-  const chain = () => editor?.chain().focus() as any;
+  const chain = () => editor?.chain().focus() as any
+  const isEditorActive = (name: string, attributes?: Record<string, unknown>) =>
+    Boolean(
+      editor?.isFocused &&
+      (attributes ? editor.isActive(name, attributes) : editor.isActive(name))
+    )
+  const getCurrentBlockLabel = () => {
+    if (!editor?.isFocused) return "H"
+    if (editor.isActive("heading", { level: 1 })) return "H1"
+    if (editor.isActive("heading", { level: 2 })) return "H2"
+    if (editor.isActive("heading", { level: 3 })) return "H3"
+    return "Body"
+  }
+  const isBodyActive = () =>
+    Boolean(
+      editor?.isFocused &&
+      !editor.isActive("heading") &&
+      !editor.isActive("blockquote") &&
+      !editor.isActive("bulletList") &&
+      !editor.isActive("orderedList") &&
+      !editor.isActive("codeBlock")
+    )
 
   const items: ToolbarItem[] = useMemo(
     () =>
       editor
         ? [
-            { action: () => chain()?.toggleBold().run(), group: 1, icon: <Bold size={16} />, id: 'bold', isActive: () => editor.isActive('bold'), label: 'Bold' },
-            { action: () => chain()?.toggleItalic().run(), group: 1, icon: <Italic size={16} />, id: 'italic', isActive: () => editor.isActive('italic'), label: 'Italic' },
-            { action: () => chain()?.toggleUnderline().run(), group: 1, icon: <Underline size={16} />, id: 'underline', isActive: () => editor.isActive('underline'), label: 'Underline' },
-            { action: () => chain()?.toggleStrike().run(), group: 1, icon: <Strikethrough size={16} />, id: 'strike', isActive: () => editor.isActive('strike'), label: 'Strikethrough' },
+            {
+              action: () => chain()?.toggleBold().run(),
+              group: 1,
+              icon: <Bold size={16} />,
+              id: "bold",
+              isActive: () => isEditorActive("bold"),
+              label: "Bold",
+            },
+            {
+              action: () => chain()?.toggleItalic().run(),
+              group: 1,
+              icon: <Italic size={16} />,
+              id: "italic",
+              isActive: () => isEditorActive("italic"),
+              label: "Italic",
+            },
+            {
+              action: () => chain()?.toggleUnderline().run(),
+              group: 1,
+              icon: <Underline size={16} />,
+              id: "underline",
+              isActive: () => isEditorActive("underline"),
+              label: "Underline",
+            },
+            {
+              action: () => chain()?.toggleStrike().run(),
+              group: 1,
+              icon: <Strikethrough size={16} />,
+              id: "strike",
+              isActive: () => isEditorActive("strike"),
+              label: "Strikethrough",
+            },
             {
               action: () => {
-                const previousUrl = editor.getAttributes('link').href;
-                setLinkUrl(previousUrl || '');
-                setLinkPopoverOpen(true);
+                const previousUrl = editor.getAttributes("link").href
+                setLinkUrl(previousUrl || "")
+                setLinkPopoverOpen(true)
               },
               group: 2,
               icon: <Link size={16} />,
-              id: 'link',
-              isActive: () => editor.isActive('link'),
-              label: 'Link',
+              id: "link",
+              isActive: () => isEditorActive("link"),
+              label: "Link",
             },
-            { action: () => chain()?.toggleCode().run(), group: 3, icon: <Code size={16} />, id: 'code', isActive: () => editor.isActive('code'), label: 'Inline Code' },
-            { action: () => chain()?.toggleCodeBlock().run(), group: 3, icon: <Code2 size={16} />, id: 'codeBlock', isActive: () => editor.isActive('codeBlock'), label: 'Code Block' },
-            { action: () => chain()?.toggleBlockquote().run(), group: 4, icon: <Quote size={16} />, id: 'blockquote', isActive: () => editor.isActive('blockquote'), label: 'Quote' },
-            { action: () => chain()?.toggleBulletList().run(), group: 5, icon: <List size={16} />, id: 'bulletList', isActive: () => editor.isActive('bulletList'), label: 'Bullet List' },
-            { action: () => chain()?.toggleOrderedList().run(), group: 5, icon: <ListOrdered size={16} />, id: 'orderedList', isActive: () => editor.isActive('orderedList'), label: 'Numbered List' },
+            {
+              action: () => chain()?.toggleCode().run(),
+              group: 3,
+              icon: <Code size={16} />,
+              id: "code",
+              isActive: () => isEditorActive("code"),
+              label: "Inline Code",
+            },
+            {
+              action: () => chain()?.toggleCodeBlock().run(),
+              group: 3,
+              icon: <Code2 size={16} />,
+              id: "codeBlock",
+              isActive: () => isEditorActive("codeBlock"),
+              label: "Code Block",
+            },
+            {
+              action: () => chain()?.toggleBlockquote().run(),
+              group: 4,
+              icon: <Quote size={16} />,
+              id: "blockquote",
+              isActive: () => isEditorActive("blockquote"),
+              label: "Quote",
+            },
+            {
+              action: () => chain()?.toggleBulletList().run(),
+              group: 5,
+              icon: <List size={16} />,
+              id: "bulletList",
+              isActive: () => isEditorActive("bulletList"),
+              label: "Bullet List",
+            },
+            {
+              action: () => chain()?.toggleOrderedList().run(),
+              group: 5,
+              icon: <ListOrdered size={16} />,
+              id: "orderedList",
+              isActive: () => isEditorActive("orderedList"),
+              label: "Numbered List",
+            },
             {
               action: () => {},
               group: 6,
               icon: <Heading size={16} />,
-              id: 'heading',
-              isActive: () =>
-                editor.isActive('heading', { level: 4 }) ||
-                editor.isActive('heading', { level: 5 }) ||
-                editor.isActive('heading', { level: 6 }),
-              label: 'Heading',
+              id: "heading",
+              isActive: () => isEditorActive("heading"),
+              label: "Heading",
+              width: 56,
             },
           ]
         : [],
     [editor]
-  );
+  )
 
   const calculateOverflow = useCallback(() => {
-    if (!toolbarRef.current) return;
-    const containerWidth = toolbarRef.current.offsetWidth;
-    const buttonWidth = 36;
-    const dividerWidth = 17;
-    const overflowButtonWidth = 40;
-    const padding = 8;
+    if (!toolbarRef.current) return
+    const containerWidth = toolbarRef.current.offsetWidth
+    const defaultButtonWidth = 36
+    const dividerWidth = 17
+    const overflowButtonWidth = 40
+    const padding = 8
 
-    let usedWidth = padding + overflowButtonWidth;
-    let lastGroup = 0;
-    const visible: ToolbarItem[] = [];
-    const overflow: ToolbarItem[] = [];
+    let usedWidth = padding + overflowButtonWidth
+    let lastGroup = 0
+    const visible: ToolbarItem[] = []
+    const overflow: ToolbarItem[] = []
 
     for (const item of items) {
-      if (item.group !== lastGroup && lastGroup !== 0) usedWidth += dividerWidth;
-      if (usedWidth + buttonWidth <= containerWidth) {
-        visible.push(item);
-        usedWidth += buttonWidth;
+      if (item.group !== lastGroup && lastGroup !== 0) usedWidth += dividerWidth
+      const itemWidth = item.width ?? defaultButtonWidth
+      if (usedWidth + itemWidth <= containerWidth) {
+        visible.push(item)
+        usedWidth += itemWidth
       } else {
-        overflow.push(item);
+        overflow.push(item)
       }
-      lastGroup = item.group;
+      lastGroup = item.group
     }
 
-    setVisibleItems(visible);
-    setOverflowItems(overflow);
-  }, [items]);
+    setVisibleItems(visible)
+    setOverflowItems(overflow)
+  }, [items])
 
   useEffect(() => {
-    calculateOverflow();
-    const resizeObserver = new ResizeObserver(calculateOverflow);
-    if (toolbarRef.current) resizeObserver.observe(toolbarRef.current);
-    return () => resizeObserver.disconnect();
-  }, [calculateOverflow]);
+    if (!editor) return
+
+    const rerenderToolbar = () => {
+      setEditorStateVersion((version) => version + 1)
+    }
+
+    editor.on("transaction", rerenderToolbar)
+    editor.on("selectionUpdate", rerenderToolbar)
+    editor.on("focus", rerenderToolbar)
+    editor.on("blur", rerenderToolbar)
+
+    return () => {
+      editor.off("transaction", rerenderToolbar)
+      editor.off("selectionUpdate", rerenderToolbar)
+      editor.off("focus", rerenderToolbar)
+      editor.off("blur", rerenderToolbar)
+    }
+  }, [editor])
+
+  useEffect(() => {
+    calculateOverflow()
+    const resizeObserver = new ResizeObserver(calculateOverflow)
+    if (toolbarRef.current) resizeObserver.observe(toolbarRef.current)
+    return () => resizeObserver.disconnect()
+  }, [calculateOverflow])
 
   const applyLink = () => {
     if (linkUrl) {
-      chain()?.extendMarkRange('link').setLink({ href: linkUrl, target: '_blank' }).run();
+      chain()
+        ?.extendMarkRange("link")
+        .setLink({ href: linkUrl, target: "_blank" })
+        .run()
     } else {
-      chain()?.extendMarkRange('link').unsetLink().run();
+      chain()?.extendMarkRange("link").unsetLink().run()
     }
-    setLinkPopoverOpen(false);
-    setLinkUrl('');
-  };
+    setLinkPopoverOpen(false)
+    setLinkUrl("")
+  }
 
-  if (!editor) return null;
+  if (!editor) return null
+
+  const activeButtonClass =
+    "border-border bg-accent text-accent-foreground shadow-xs"
 
   const renderItem = (item: ToolbarItem) => {
-    if (item.id === 'heading') {
+    if (item.id === "heading") {
       return (
         <DropdownMenu key={item.id}>
           <DropdownMenuTrigger asChild>
-            <Button className={cn('h-8 w-8 p-0', item.isActive?.() && 'bg-accent')} size="sm" type="button" variant="ghost">
-              {item.icon}
+            <Button
+              aria-label={`Text style: ${getCurrentBlockLabel()}`}
+              className={cn(
+                "h-8 min-w-14 gap-1.5 px-2",
+                item.isActive?.() && activeButtonClass
+              )}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              <Heading size={16} />
+              <span className="text-[11px] font-semibold tracking-wide">
+                {getCurrentBlockLabel()}
+              </span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            <DropdownMenuItem onClick={() => chain()?.toggleHeading({ level: 4 }).run()}>Heading 1</DropdownMenuItem>
-            <DropdownMenuItem onClick={() => chain()?.toggleHeading({ level: 5 }).run()}>Heading 2</DropdownMenuItem>
-            <DropdownMenuItem onClick={() => chain()?.toggleHeading({ level: 6 }).run()}>Heading 3</DropdownMenuItem>
+            <DropdownMenuItem
+              className={cn(isBodyActive() && "font-medium")}
+              onClick={() => chain()?.setParagraph().run()}
+            >
+              <Check
+                className={cn(
+                  "mr-2 size-4",
+                  isBodyActive() ? "opacity-100" : "opacity-0"
+                )}
+              />
+              Body
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={cn(
+                isEditorActive("heading", { level: 1 }) && "font-medium"
+              )}
+              onClick={() => chain()?.toggleHeading({ level: 1 }).run()}
+            >
+              <Check
+                className={cn(
+                  "mr-2 size-4",
+                  isEditorActive("heading", { level: 1 })
+                    ? "opacity-100"
+                    : "opacity-0"
+                )}
+              />
+              Heading 1
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={cn(
+                isEditorActive("heading", { level: 2 }) && "font-medium"
+              )}
+              onClick={() => chain()?.toggleHeading({ level: 2 }).run()}
+            >
+              <Check
+                className={cn(
+                  "mr-2 size-4",
+                  isEditorActive("heading", { level: 2 })
+                    ? "opacity-100"
+                    : "opacity-0"
+                )}
+              />
+              Heading 2
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={cn(
+                isEditorActive("heading", { level: 3 }) && "font-medium"
+              )}
+              onClick={() => chain()?.toggleHeading({ level: 3 }).run()}
+            >
+              <Check
+                className={cn(
+                  "mr-2 size-4",
+                  isEditorActive("heading", { level: 3 })
+                    ? "opacity-100"
+                    : "opacity-0"
+                )}
+              />
+              Heading 3
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-      );
+      )
     }
 
-    if (item.id === 'link') {
+    if (item.id === "link") {
       return (
-        <Popover key={item.id} onOpenChange={setLinkPopoverOpen} open={linkPopoverOpen}>
+        <Popover
+          key={item.id}
+          onOpenChange={setLinkPopoverOpen}
+          open={linkPopoverOpen}
+        >
           <PopoverTrigger asChild>
-            <Button className={cn('h-8 w-8 p-0', item.isActive?.() && 'bg-accent')} onClick={item.action} size="sm" type="button" variant="ghost">
+            <Button
+              aria-label={item.label}
+              className={cn(
+                "h-8 w-8 p-0",
+                item.isActive?.() && activeButtonClass
+              )}
+              onClick={item.action}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
               {item.icon}
             </Button>
           </PopoverTrigger>
@@ -172,9 +382,9 @@ export function EditorToolbar({ editor }: { editor: Editor | null }) {
                 </Button>
                 <Button
                   onClick={() => {
-                    chain()?.extendMarkRange('link').unsetLink().run();
-                    setLinkPopoverOpen(false);
-                    setLinkUrl('');
+                    chain()?.extendMarkRange("link").unsetLink().run()
+                    setLinkPopoverOpen(false)
+                    setLinkUrl("")
                   }}
                   size="sm"
                   type="button"
@@ -186,13 +396,17 @@ export function EditorToolbar({ editor }: { editor: Editor | null }) {
             </div>
           </PopoverContent>
         </Popover>
-      );
+      )
     }
 
     return (
       <Button
+        aria-label={item.label}
+        aria-pressed={
+          toggleButtonIds.has(item.id) ? item.isActive?.() : undefined
+        }
         key={item.id}
-        className={cn('h-8 w-8 p-0', item.isActive?.() && 'bg-accent')}
+        className={cn("h-8 w-8 p-0", item.isActive?.() && activeButtonClass)}
         onClick={item.action}
         size="sm"
         title={item.label}
@@ -201,18 +415,20 @@ export function EditorToolbar({ editor }: { editor: Editor | null }) {
       >
         {item.icon}
       </Button>
-    );
-  };
+    )
+  }
 
-  const groupedVisible: React.ReactNode[] = [];
-  let lastGroup = 0;
+  const groupedVisible: React.ReactNode[] = []
+  let lastGroup = 0
   visibleItems.forEach((item, index) => {
     if (item.group !== lastGroup && lastGroup !== 0) {
-      groupedVisible.push(<div key={`divider-${index}`} className="mx-1 h-6 w-px bg-border" />);
+      groupedVisible.push(
+        <div key={`divider-${index}`} className="mx-1 h-6 w-px bg-border" />
+      )
     }
-    groupedVisible.push(renderItem(item));
-    lastGroup = item.group;
-  });
+    groupedVisible.push(renderItem(item))
+    lastGroup = item.group
+  })
 
   return (
     <div className="border-b bg-muted/30 px-2 py-1">
@@ -221,13 +437,30 @@ export function EditorToolbar({ editor }: { editor: Editor | null }) {
         {overflowItems.length > 0 ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="ml-auto h-8 w-8 p-0" size="sm" type="button" variant="ghost">
+              <Button
+                className="ml-auto h-8 w-8 p-0"
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
                 <MoreHorizontal size={16} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {overflowItems.map((item) => (
-                <DropdownMenuItem key={item.id} onClick={item.action}>
+                <DropdownMenuItem
+                  className={cn(item.isActive?.() && "font-medium")}
+                  key={item.id}
+                  onClick={item.action}
+                >
+                  {item.id !== "heading" ? (
+                    <Check
+                      className={cn(
+                        "mr-2 size-4",
+                        item.isActive?.() ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                  ) : null}
                   {item.icon}
                   {item.label}
                 </DropdownMenuItem>
@@ -237,5 +470,5 @@ export function EditorToolbar({ editor }: { editor: Editor | null }) {
         ) : null}
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/editor/format-content-for-display.test.ts
+++ b/src/components/editor/format-content-for-display.test.ts
@@ -22,6 +22,14 @@ describe("formatContentForDisplay", () => {
     )
   })
 
+  it("keeps inline code content escaped", () => {
+    const html = "<p>Use `&lt;img src=x onerror=alert(1)&gt;` here.</p>"
+
+    expect(formatContentForDisplay(html)).toBe(
+      "<p>Use <code>&lt;img src=x onerror=alert(1)&gt;</code> here.</p>"
+    )
+  })
+
   it("leaves non-code content unchanged", () => {
     const html = "<p>Just text.</p>"
 

--- a/src/components/editor/format-content-for-display.test.ts
+++ b/src/components/editor/format-content-for-display.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { formatContentForDisplay } from "./format-content-for-display"
+
+describe("formatContentForDisplay", () => {
+  it("adds syntax highlighting classes to fenced code blocks", () => {
+    const html =
+      '<pre><code class="language-typescript">const value = &quot;ok&quot;</code></pre>'
+
+    const formatted = formatContentForDisplay(html)
+
+    expect(formatted).toContain('class="language-typescript hljs"')
+    expect(formatted).toContain("hljs-keyword")
+    expect(formatted).toContain("&quot;ok&quot;")
+  })
+
+  it("formats inline backticks as inline code", () => {
+    const html = "<p>Use `pnpm build` here.</p>"
+
+    expect(formatContentForDisplay(html)).toBe(
+      "<p>Use <code>pnpm build</code> here.</p>"
+    )
+  })
+
+  it("leaves non-code content unchanged", () => {
+    const html = "<p>Just text.</p>"
+
+    expect(formatContentForDisplay(html)).toBe(html)
+  })
+})

--- a/src/components/editor/format-content-for-display.ts
+++ b/src/components/editor/format-content-for-display.ts
@@ -1,11 +1,12 @@
 import { common, createLowlight } from "lowlight"
 
+import { formatInlineCode } from "./format-inline-code"
+
 const lowlight = createLowlight(common)
 
 const CODE_BLOCK_REGEX =
   /<pre([^>]*)>\s*<code([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/gi
 const CLASS_ATTRIBUTE_REGEX = /\bclass=(["'])(.*?)\1/i
-const INLINE_CODE_REGEX = /(^|[^`])`([^`\n]+)`(?!`)/g
 const LANGUAGE_CLASS_PREFIX = "language-"
 
 type HighlightNode = {
@@ -120,35 +121,6 @@ function serializeHighlightedNodes(nodes: HighlightNode[]): string {
       return `<${node.tagName}${attributes}>${serializeHighlightedNodes(
         node.children ?? []
       )}</${node.tagName}>`
-    })
-    .join("")
-}
-
-function formatInlineCode(html: string) {
-  let insideCode = false
-  let insidePre = false
-
-  return html
-    .split(/(<\/?[^>]+>)/g)
-    .filter(Boolean)
-    .map((part) => {
-      if (part.startsWith("<")) {
-        if (/^<pre\b/i.test(part)) insidePre = true
-        if (/^<\/pre/i.test(part)) insidePre = false
-        if (/^<code\b/i.test(part)) insideCode = true
-        if (/^<\/code/i.test(part)) insideCode = false
-        return part
-      }
-
-      if (insideCode || insidePre) {
-        return part
-      }
-
-      return part.replace(
-        INLINE_CODE_REGEX,
-        (_match, prefix: string, code: string) =>
-          `${prefix}<code>${code}</code>`
-      )
     })
     .join("")
 }

--- a/src/components/editor/format-content-for-display.ts
+++ b/src/components/editor/format-content-for-display.ts
@@ -1,0 +1,177 @@
+import { common, createLowlight } from "lowlight"
+
+const lowlight = createLowlight(common)
+
+const CODE_BLOCK_REGEX =
+  /<pre([^>]*)>\s*<code([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/gi
+const CLASS_ATTRIBUTE_REGEX = /\bclass=(["'])(.*?)\1/i
+const INLINE_CODE_REGEX = /(^|[^`])`([^`\n]+)`(?!`)/g
+const LANGUAGE_CLASS_PREFIX = "language-"
+
+type HighlightNode = {
+  children?: HighlightNode[]
+  properties?: {
+    className?: string[]
+  }
+  tagName?: string
+  value?: string
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+function decodeHtmlEntities(value: string) {
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (entity, token) => {
+    if (token[0] === "#") {
+      const isHex = token[1]?.toLowerCase() === "x"
+      const codePoint = Number.parseInt(
+        token.slice(isHex ? 2 : 1),
+        isHex ? 16 : 10
+      )
+
+      if (Number.isNaN(codePoint)) {
+        return entity
+      }
+
+      return String.fromCodePoint(codePoint)
+    }
+
+    switch (token) {
+      case "amp":
+        return "&"
+      case "apos":
+      case "nbsp":
+        return token === "nbsp" ? " " : "'"
+      case "gt":
+        return ">"
+      case "lt":
+        return "<"
+      case "quot":
+        return '"'
+      default:
+        return entity
+    }
+  })
+}
+
+function getClassNames(attributes: string) {
+  const classValue = attributes.match(CLASS_ATTRIBUTE_REGEX)?.[2]
+
+  if (!classValue) {
+    return []
+  }
+
+  return classValue.split(/\s+/).filter(Boolean)
+}
+
+function mergeClassNames(attributes: string, classNames: string[]) {
+  const mergedClassNames = Array.from(
+    new Set([...getClassNames(attributes), ...classNames])
+  )
+
+  if (mergedClassNames.length === 0) {
+    return attributes
+  }
+
+  const nextClassAttribute = `class="${mergedClassNames.join(" ")}"`
+
+  if (CLASS_ATTRIBUTE_REGEX.test(attributes)) {
+    return attributes.replace(CLASS_ATTRIBUTE_REGEX, nextClassAttribute)
+  }
+
+  return `${attributes} ${nextClassAttribute}`
+}
+
+function getLanguage(attributes: string) {
+  return (
+    getClassNames(attributes)
+      .find((className) => className.startsWith(LANGUAGE_CLASS_PREFIX))
+      ?.slice(LANGUAGE_CLASS_PREFIX.length) ?? null
+  )
+}
+
+function serializeHighlightedNodes(nodes: HighlightNode[]): string {
+  return nodes
+    .map((node) => {
+      if (typeof node.value === "string") {
+        return escapeHtml(node.value)
+      }
+
+      if (!node.tagName) {
+        return serializeHighlightedNodes(node.children ?? [])
+      }
+
+      const classNames = Array.isArray(node.properties?.className)
+        ? node.properties.className.filter(
+            (className): className is string => typeof className === "string"
+          )
+        : []
+
+      const attributes = classNames.length
+        ? ` class="${escapeHtml(classNames.join(" "))}"`
+        : ""
+
+      return `<${node.tagName}${attributes}>${serializeHighlightedNodes(
+        node.children ?? []
+      )}</${node.tagName}>`
+    })
+    .join("")
+}
+
+function formatInlineCode(html: string) {
+  let insideCode = false
+  let insidePre = false
+
+  return html
+    .split(/(<\/?[^>]+>)/g)
+    .filter(Boolean)
+    .map((part) => {
+      if (part.startsWith("<")) {
+        if (/^<pre\b/i.test(part)) insidePre = true
+        if (/^<\/pre/i.test(part)) insidePre = false
+        if (/^<code\b/i.test(part)) insideCode = true
+        if (/^<\/code/i.test(part)) insideCode = false
+        return part
+      }
+
+      if (insideCode || insidePre) {
+        return part
+      }
+
+      return part.replace(
+        INLINE_CODE_REGEX,
+        (_match, prefix: string, code: string) =>
+          `${prefix}<code>${code}</code>`
+      )
+    })
+    .join("")
+}
+
+export function formatContentForDisplay(html: string) {
+  return formatInlineCode(html).replace(
+    CODE_BLOCK_REGEX,
+    (_match, preAttributes = "", codeAttributes = "", encodedCode = "") => {
+      const language = getLanguage(codeAttributes)
+      const code = decodeHtmlEntities(encodedCode).replace(/\r\n?/g, "\n")
+      const result =
+        language && lowlight.listLanguages().includes(language)
+          ? lowlight.highlight(language, code)
+          : lowlight.highlightAuto(code)
+      const highlightedNodes = Array.isArray(result.children)
+        ? (result.children as HighlightNode[])
+        : []
+
+      const highlightedCode = serializeHighlightedNodes(highlightedNodes)
+
+      return `<pre${preAttributes}><code${mergeClassNames(codeAttributes, [
+        "hljs",
+      ])}>${highlightedCode || escapeHtml(code)}</code></pre>`
+    }
+  )
+}

--- a/src/components/editor/format-inline-code.ts
+++ b/src/components/editor/format-inline-code.ts
@@ -1,0 +1,73 @@
+const INLINE_CODE_REGEX = /(^|[^`])`([^`\n]+)`(?!`)/g
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+function decodeHtmlEntities(value: string) {
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (entity, token) => {
+    if (token[0] === "#") {
+      const isHex = token[1]?.toLowerCase() === "x"
+      const codePoint = Number.parseInt(
+        token.slice(isHex ? 2 : 1),
+        isHex ? 16 : 10
+      )
+
+      if (Number.isNaN(codePoint)) {
+        return entity
+      }
+
+      return String.fromCodePoint(codePoint)
+    }
+
+    switch (token) {
+      case "amp":
+        return "&"
+      case "apos":
+      case "nbsp":
+        return token === "nbsp" ? " " : "'"
+      case "gt":
+        return ">"
+      case "lt":
+        return "<"
+      case "quot":
+        return '"'
+      default:
+        return entity
+    }
+  })
+}
+
+export function formatInlineCode(html: string) {
+  let insideCode = false
+  let insidePre = false
+
+  return html
+    .split(/(<\/?[^>]+>)/g)
+    .filter(Boolean)
+    .map((part) => {
+      if (part.startsWith("<")) {
+        if (/^<pre\b/i.test(part)) insidePre = true
+        if (/^<\/pre/i.test(part)) insidePre = false
+        if (/^<code\b/i.test(part)) insideCode = true
+        if (/^<\/code/i.test(part)) insideCode = false
+        return part
+      }
+
+      if (insideCode || insidePre) {
+        return part
+      }
+
+      return part.replace(
+        INLINE_CODE_REGEX,
+        (_match, prefix: string, code: string) =>
+          `${prefix}<code>${escapeHtml(decodeHtmlEntities(code))}</code>`
+      )
+    })
+    .join("")
+}

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -14,7 +14,7 @@ function createExtensions(placeholder: string) {
   return [
     StarterKit.configure({
       codeBlock: false,
-      heading: { levels: [4, 5, 6] },
+      heading: { levels: [1, 2, 3, 4, 5, 6] },
       link: false,
       underline: false,
     }),
@@ -89,16 +89,7 @@ export const MarkdownEditor = forwardRef<
       editable: !disabled,
       editorProps: {
         attributes: {
-          class: cn(
-            "prose prose-base max-w-none px-4 py-3 text-foreground focus:outline-none dark:prose-invert",
-            "prose-headings:font-semibold",
-            "prose-h4:text-[1.1rem] prose-h5:text-[1rem] prose-h6:text-[0.95rem]",
-            "prose-a:text-primary prose-a:no-underline hover:prose-a:underline",
-            "prose-code:before:content-none prose-code:after:content-none",
-            "prose-blockquote:border-l-2 prose-blockquote:border-border prose-blockquote:pl-4 prose-blockquote:text-muted-foreground prose-blockquote:not-italic prose-blockquote:before:content-none prose-blockquote:after:content-none",
-            "[&>blockquote:first-child>*:first-child]:mt-0",
-            "prose-ol:my-1.5 prose-ul:my-1.5 prose-li:my-0 prose-li:leading-snug"
-          ),
+          class: cn("markdown-prose px-4 py-3 focus:outline-none"),
         },
         handleKeyDown: (_view, event) => {
           if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,329 +1,460 @@
-@import 'tailwindcss' source('../');
-@import 'tw-animate-css';
+@import "@fontsource-variable/geist-mono";
+@import "tailwindcss" source("../");
+@import "tw-animate-css";
 
-@plugin 'tailwindcss-hocus';
-@plugin '@tailwindcss/typography';
+@plugin "tailwindcss-hocus";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	--absolute: oklch(1 0 0);
-	--background: oklch(0.98 0 0);
-	--foreground: oklch(0.1448 0 0);
-	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.1448 0 0);
-	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.1448 0 0);
-	--primary: oklch(0.5461 0.2152 262.8809);
-	--primary-foreground: oklch(1 0 0);
-	--secondary: oklch(0.9702 0 0);
-	--secondary-foreground: oklch(0.1448 0 0);
-	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.5555 0 0);
-	--accent: oklch(0.91 0 0);
-	--accent-foreground: oklch(0.1448 0 0);
-	--destructive: oklch(0.5771 0.2152 27.325);
-	--destructive-foreground: oklch(1 0 0);
-	--border: oklch(0.89 0 0);
-	--input: oklch(0.75 0 0);
-	--ring: oklch(0.7155 0 0);
-	--chart-1: oklch(0.5461 0.2152 262.8809);
-	--chart-2: oklch(0.5575 0.2525 302.3212);
-	--chart-3: oklch(0.6002 0.1038 184.704);
-	--chart-4: oklch(0.6461 0.1943 41.1158);
-	--chart-5: oklch(0.5771 0.2152 27.325);
-	--sidebar: oklch(0.9851 0 0);
-	--sidebar-foreground: oklch(0.1448 0 0);
-	--sidebar-primary: oklch(0.5461 0.2152 262.8809);
-	--sidebar-primary-foreground: oklch(1 0 0);
-	--sidebar-accent: oklch(1 0 0);
-	--sidebar-accent-foreground: oklch(0.1448 0 0);
-	--sidebar-border: oklch(0.9219 0 0);
-	--sidebar-ring: oklch(0.7155 0 0);
-	--font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
-	--font-serif: serif;
-	--font-mono: Geist Mono;
-	--radius: 0.45rem;
-	--shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
-	--shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
-	--shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
-	--shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
-	--shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 2px 4px -1px hsl(0 0% 0% / 0.1);
-	--shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 4px 6px -1px hsl(0 0% 0% / 0.1);
-	--shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 8px 10px -1px hsl(0 0% 0% / 0.1);
-	--shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
-	--tracking-normal: 0rem;
-	--spacing: 0.25rem;
+  --absolute: oklch(1 0 0);
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.1448 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.1448 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.1448 0 0);
+  --primary: oklch(0.5461 0.2152 262.8809);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.9702 0 0);
+  --secondary-foreground: oklch(0.1448 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.5555 0 0);
+  --accent: oklch(0.91 0 0);
+  --accent-foreground: oklch(0.1448 0 0);
+  --destructive: oklch(0.5771 0.2152 27.325);
+  --destructive-foreground: oklch(1 0 0);
+  --border: oklch(0.89 0 0);
+  --input: oklch(0.75 0 0);
+  --ring: oklch(0.7155 0 0);
+  --chart-1: oklch(0.5461 0.2152 262.8809);
+  --chart-2: oklch(0.5575 0.2525 302.3212);
+  --chart-3: oklch(0.6002 0.1038 184.704);
+  --chart-4: oklch(0.6461 0.1943 41.1158);
+  --chart-5: oklch(0.5771 0.2152 27.325);
+  --sidebar: oklch(0.9851 0 0);
+  --sidebar-foreground: oklch(0.1448 0 0);
+  --sidebar-primary: oklch(0.5461 0.2152 262.8809);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(1 0 0);
+  --sidebar-accent-foreground: oklch(0.1448 0 0);
+  --sidebar-border: oklch(0.9219 0 0);
+  --sidebar-ring: oklch(0.7155 0 0);
+  --font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
+  --font-serif: serif;
+  --font-mono:
+    "Geist Mono Variable", "Geist Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
+  --radius: 0.45rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+  --tracking-normal: 0rem;
+  --spacing: 0.25rem;
 }
 
 .dark {
-	--absolute: oklch(0 0 0);
-	--background: oklch(0.15 0 0);
-	--foreground: oklch(1 0 0);
-	--card: oklch(0.1 0 0);
-	--card-foreground: oklch(0.9842 0.0034 247.8575);
-	--popover: oklch(0 0 0);
-	--popover-foreground: oklch(0.9842 0.0034 247.8575);
-	--primary: oklch(0.6231 0.188 259.8145);
-	--primary-foreground: oklch(1 0 0);
-	--secondary: oklch(0.2046 0 0);
-	--secondary-foreground: oklch(0.9842 0.0034 247.8575);
-	--muted: oklch(0.18 0 0);
-	--muted-foreground: oklch(0.7155 0 0);
-	--accent: oklch(0.3 0 0);
-	--accent-foreground: oklch(0.9842 0.0034 247.8575);
-	--destructive: oklch(0.6368 0.2078 25.3313);
-	--destructive-foreground: oklch(0.9842 0.0034 247.8575);
-	--border: oklch(0.35 0 0);
-	--input: oklch(0.35 0 0);
-	--ring: oklch(0.6231 0.188 259.8145);
-	--chart-1: oklch(0.6231 0.188 259.8145);
-	--chart-2: oklch(0.6268 0.2325 303.9004);
-	--chart-3: oklch(0.7038 0.123 182.5025);
-	--chart-4: oklch(0.7049 0.1867 47.6044);
-	--chart-5: oklch(0.6368 0.2078 25.3313);
-	--sidebar: oklch(0 0 0);
-	--sidebar-foreground: oklch(0.9842 0.0034 247.8575);
-	--sidebar-primary: oklch(0.6231 0.188 259.8145);
-	--sidebar-primary-foreground: oklch(1 0 0);
-	--sidebar-accent: oklch(0.2046 0 0);
-	--sidebar-accent-foreground: oklch(0.9842 0.0034 247.8575);
-	--sidebar-border: oklch(0.2686 0 0);
-	--sidebar-ring: oklch(0.6231 0.188 259.8145);
-	--font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
-	--font-serif: serif;
-	--font-mono: Geist Mono;
-	--radius: 0.45rem;
-	--shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
-	--shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
-	--shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
-	--shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
-	--shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 2px 4px -1px hsl(0 0% 0% / 0.1);
-	--shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 4px 6px -1px hsl(0 0% 0% / 0.1);
-	--shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 8px 10px -1px hsl(0 0% 0% / 0.1);
-	--shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
+  --absolute: oklch(0 0 0);
+  --background: oklch(0.15 0 0);
+  --foreground: oklch(1 0 0);
+  --card: oklch(0.1 0 0);
+  --card-foreground: oklch(0.9842 0.0034 247.8575);
+  --popover: oklch(0 0 0);
+  --popover-foreground: oklch(0.9842 0.0034 247.8575);
+  --primary: oklch(0.6231 0.188 259.8145);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.2046 0 0);
+  --secondary-foreground: oklch(0.9842 0.0034 247.8575);
+  --muted: oklch(0.18 0 0);
+  --muted-foreground: oklch(0.7155 0 0);
+  --accent: oklch(0.3 0 0);
+  --accent-foreground: oklch(0.9842 0.0034 247.8575);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(0.9842 0.0034 247.8575);
+  --border: oklch(0.35 0 0);
+  --input: oklch(0.35 0 0);
+  --ring: oklch(0.6231 0.188 259.8145);
+  --chart-1: oklch(0.6231 0.188 259.8145);
+  --chart-2: oklch(0.6268 0.2325 303.9004);
+  --chart-3: oklch(0.7038 0.123 182.5025);
+  --chart-4: oklch(0.7049 0.1867 47.6044);
+  --chart-5: oklch(0.6368 0.2078 25.3313);
+  --sidebar: oklch(0 0 0);
+  --sidebar-foreground: oklch(0.9842 0.0034 247.8575);
+  --sidebar-primary: oklch(0.6231 0.188 259.8145);
+  --sidebar-primary-foreground: oklch(1 0 0);
+  --sidebar-accent: oklch(0.2046 0 0);
+  --sidebar-accent-foreground: oklch(0.9842 0.0034 247.8575);
+  --sidebar-border: oklch(0.2686 0 0);
+  --sidebar-ring: oklch(0.6231 0.188 259.8145);
+  --font-sans: Inter, ui-sans-serif, sans-serif, system-ui;
+  --font-serif: serif;
+  --font-mono:
+    "Geist Mono Variable", "Geist Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, monospace;
+  --radius: 0.45rem;
+  --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.05);
+  --shadow-sm:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 1px 2px -1px hsl(0 0% 0% / 0.1);
+  --shadow-md:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 2px 4px -1px hsl(0 0% 0% / 0.1);
+  --shadow-lg:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 4px 6px -1px hsl(0 0% 0% / 0.1);
+  --shadow-xl:
+    0px 2px 4px 0px hsl(0 0% 0% / 0.1), 0px 8px 10px -1px hsl(0 0% 0% / 0.1);
+  --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.25);
 }
 
 @theme inline {
-	--color-absolute: var(--absolute);
-	--color-background: var(--background);
-	--color-foreground: var(--foreground);
-	--color-card: var(--card);
-	--color-card-foreground: var(--card-foreground);
-	--color-popover: var(--popover);
-	--color-popover-foreground: var(--popover-foreground);
-	--color-primary: var(--primary);
-	--color-primary-foreground: var(--primary-foreground);
-	--color-secondary: var(--secondary);
-	--color-secondary-foreground: var(--secondary-foreground);
-	--color-muted: var(--muted);
-	--color-muted-foreground: var(--muted-foreground);
-	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
-	--color-border: var(--border);
-	--color-input: var(--input);
-	--color-ring: var(--ring);
-	--color-chart-1: var(--chart-1);
-	--color-chart-2: var(--chart-2);
-	--color-chart-3: var(--chart-3);
-	--color-chart-4: var(--chart-4);
-	--color-chart-5: var(--chart-5);
-	--color-sidebar: var(--sidebar);
-	--color-sidebar-foreground: var(--sidebar-foreground);
-	--color-sidebar-primary: var(--sidebar-primary);
-	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-	--color-sidebar-accent: var(--sidebar-accent);
-	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-	--color-sidebar-border: var(--sidebar-border);
-	--color-sidebar-ring: var(--sidebar-ring);
+  --color-absolute: var(--absolute);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 
-	--font-sans: var(--font-sans);
-	--font-mono: var(--font-mono);
-	--font-serif: var(--font-serif);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
 
-	--radius-sm: calc(var(--radius) - 4px);
-	--radius-md: calc(var(--radius) - 2px);
-	--radius-lg: var(--radius);
-	--radius-xl: calc(var(--radius) + 4px);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
 
-	--shadow-2xs: var(--shadow-2xs);
-	--shadow-xs: var(--shadow-xs);
-	--shadow-sm: var(--shadow-sm);
-	--shadow: var(--shadow);
-	--shadow-md: var(--shadow-md);
-	--shadow-lg: var(--shadow-lg);
-	--shadow-xl: var(--shadow-xl);
-	--shadow-2xl: var(--shadow-2xl);
+  --shadow-2xs: var(--shadow-2xs);
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow: var(--shadow);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
 
-	--tracking-tighter: calc(var(--tracking-normal) - 0.05em);
-	--tracking-tight: calc(var(--tracking-normal) - 0.025em);
-	--tracking-normal: var(--tracking-normal);
-	--tracking-wide: calc(var(--tracking-normal) + 0.025em);
-	--tracking-wider: calc(var(--tracking-normal) + 0.05em);
-	--tracking-widest: calc(var(--tracking-normal) + 0.1em);
+  --tracking-tighter: calc(var(--tracking-normal) - 0.05em);
+  --tracking-tight: calc(var(--tracking-normal) - 0.025em);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: calc(var(--tracking-normal) + 0.025em);
+  --tracking-wider: calc(var(--tracking-normal) + 0.05em);
+  --tracking-widest: calc(var(--tracking-normal) + 0.1em);
 }
 
 @layer base {
-	* {
-		@apply border-border outline-ring/50;
-	}
-	body {
-		@apply bg-background text-foreground;
-		letter-spacing: var(--tracking-normal);
-	}
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+    letter-spacing: var(--tracking-normal);
+  }
 }
 
 @utility container {
-	--max-width: 75rem;
-	max-width: var(--max-width);
-	margin-inline: auto;
-	padding-inline: 1rem;
-	@variant sm {
-		max-width: var(--max-width);
-	}
-	@variant lg {
-		max-width: var(--max-width);
-	}
-	@variant xl {
-		max-width: var(--max-width);
-	}
-	@variant 2xl {
-		max-width: var(--max-width);
-	}
+  --max-width: 75rem;
+  max-width: var(--max-width);
+  margin-inline: auto;
+  padding-inline: 1rem;
+  @variant sm {
+    max-width: var(--max-width);
+  }
+  @variant lg {
+    max-width: var(--max-width);
+  }
+  @variant xl {
+    max-width: var(--max-width);
+  }
+  @variant 2xl {
+    max-width: var(--max-width);
+  }
 }
 
 .container-no-center {
-	--max-width: 80rem;
-	max-width: var(--max-width);
-	padding-inline: 2rem;
+  --max-width: 80rem;
+  max-width: var(--max-width);
+  padding-inline: 2rem;
 }
 
 .disable-transitions * {
-	transition: none !important;
+  transition: none !important;
+}
+
+.markdown-prose {
+  @apply prose max-w-none text-foreground dark:prose-invert;
+}
+
+.markdown-prose > :first-child {
+  margin-top: 0;
+}
+
+.markdown-prose > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-prose :where(h1, h2, h3, h4, h5, h6) {
+  color: var(--foreground);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.markdown-prose :where(h1) {
+  font-size: 1.65rem;
+  line-height: 1.2;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.markdown-prose :where(h2) {
+  font-size: 1.35rem;
+  line-height: 1.25;
+  margin: 1.25rem 0 0.625rem;
+}
+
+.markdown-prose :where(h3) {
+  font-size: 1.15rem;
+  line-height: 1.35;
+  margin: 1rem 0 0.5rem;
+}
+
+.markdown-prose :where(h4) {
+  font-size: 1rem;
+  line-height: 1.4;
+  margin: 1rem 0 0.5rem;
+}
+
+.markdown-prose :where(h5) {
+  font-size: 0.95rem;
+  line-height: 1.45;
+  margin: 0.875rem 0 0.5rem;
+}
+
+.markdown-prose :where(h6) {
+  font-size: 0.9rem;
+  line-height: 1.45;
+  margin: 0.875rem 0 0.5rem;
+  color: var(--muted-foreground);
+}
+
+.markdown-prose :where(p) {
+  margin: 0.75rem 0;
+  line-height: 1.7;
+}
+
+.markdown-prose :where(ul, ol) {
+  margin: 0.75rem 0;
+  padding-inline-start: 1.25rem;
+}
+
+.markdown-prose :where(li) {
+  margin: 0.2rem 0;
+  line-height: 1.7;
+}
+
+.markdown-prose :where(li > p) {
+  margin: 0.2rem 0;
+}
+
+.markdown-prose :where(a) {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.markdown-prose :where(a:hover) {
+  text-decoration: underline;
+}
+
+.markdown-prose :where(strong) {
+  color: var(--foreground);
+}
+
+.markdown-prose :where(blockquote) {
+  border-left: 2px solid var(--border);
+  color: var(--muted-foreground);
+  font-style: normal;
+  margin: 1rem 0;
+  padding-left: 1rem;
+}
+
+.markdown-prose :where(code) {
+  font-family: var(--font-mono);
+}
+
+.markdown-prose :where(code:not(pre code)) {
+  background: oklch(from var(--muted) l c h / 0.42);
+  border: 1px solid oklch(from var(--border) l c h / 0.95);
+  border-radius: 0.375rem;
+  color: var(--foreground);
+  padding: 0.12rem 0.35rem;
+}
+
+.markdown-prose :where(pre) {
+  background: oklch(from var(--muted) l c h / 0.34);
+  border: 1px solid oklch(from var(--border) l c h / 0.95);
+  border-radius: 0.625rem;
+  margin: 1rem 0;
 }
 
 .link-text {
-	@apply underline decoration-current/50 decoration-2 underline-offset-2 hover:underline hover:decoration-current/75;
+  @apply underline decoration-current/50 decoration-2 underline-offset-2 hover:underline hover:decoration-current/75;
 }
 
 @utility text-gradient-primary {
-	@apply inline-block bg-linear-to-r from-blue-300 to-blue-400 bg-clip-text text-transparent dark:to-primary;
+  @apply inline-block bg-linear-to-r from-blue-300 to-blue-400 bg-clip-text text-transparent dark:to-primary;
 }
 
 /* Tiptap editor placeholder */
 .ProseMirror p.is-editor-empty:first-child::before {
-	color: var(--muted-foreground);
-	content: attr(data-placeholder);
-	float: left;
-	height: 0;
-	pointer-events: none;
+  color: var(--muted-foreground);
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
 }
 
 /* Remove quotation marks from blockquotes */
 .ProseMirror blockquote,
 .prose blockquote {
-	quotes: none;
+  quotes: none;
 }
 
 .ProseMirror blockquote::before,
 .ProseMirror blockquote::after,
 .prose blockquote::before,
 .prose blockquote::after {
-	content: none !important;
+  content: none !important;
 }
 
 .ProseMirror blockquote p::before,
 .ProseMirror blockquote p::after,
 .prose blockquote p::before,
 .prose blockquote p::after {
-	content: none !important;
+  content: none !important;
 }
 
 /* Code block styling - Editor */
 .ProseMirror .code-block-wrapper {
-	position: relative;
-	margin: 0.75rem 0;
+  position: relative;
+  margin: 0.75rem 0;
 }
 
 .ProseMirror .code-block-wrapper pre {
-	background: oklch(from var(--muted) l c h / 0.3);
-	border: 1px solid var(--border);
-	border-radius: 0.5rem;
-	padding: 0.5rem 0.75rem;
-	font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	overflow-x: auto;
-	max-width: 100%;
-	margin: 0;
+  background: oklch(from var(--muted) l c h / 0.3);
+  border: 1px solid oklch(from var(--border) l c h / 0.95);
+  border-radius: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  font-family: var(--font-mono);
+  overflow-x: auto;
+  max-width: 100%;
+  margin: 0;
 }
 
 .ProseMirror .code-block-wrapper pre code,
 .ProseMirror .code-block-wrapper pre div {
-	background: none;
-	padding: 0;
-	font-size: 0.8125rem;
-	line-height: 1.6;
-	color: var(--foreground);
-	font-family: inherit;
+  background: none;
+  padding: 0;
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--foreground);
+  font-family: inherit;
 }
 
 /* Fallback for non-wrapper code blocks */
 .ProseMirror pre:not(.code-block-wrapper pre) {
-	background: oklch(from var(--muted) l c h / 0.3);
-	border: 1px solid var(--border);
-	border-radius: 0.5rem;
-	padding: 0.5rem 0.75rem;
-	font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	overflow-x: auto;
+  background: oklch(from var(--muted) l c h / 0.3);
+  border: 1px solid oklch(from var(--border) l c h / 0.95);
+  border-radius: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  font-family: var(--font-mono);
+  overflow-x: auto;
 }
 
 .ProseMirror pre:not(.code-block-wrapper pre) code {
-	background: none;
-	padding: 0;
-	font-size: 0.8125rem;
-	line-height: 1.6;
-	color: var(--foreground);
+  background: none;
+  padding: 0;
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--foreground);
 }
 
 /* Inline code - Editor */
 .ProseMirror code:not(pre code):not(pre div) {
-	background: oklch(from var(--muted) l c h / 0.3);
-	border: 1px solid var(--border);
-	color: var(--foreground);
-	padding: 0.5rem 0.75rem;
-	border-radius: 0.375rem;
-	font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	font-size: 0.875em;
+  background: oklch(from var(--muted) l c h / 0.42);
+  border: 1px solid oklch(from var(--border) l c h / 0.95);
+  color: var(--foreground);
+  padding: 0.12rem 0.35rem;
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.875em;
 }
 
 /* Code block styling - Published content */
 .prose pre {
-	background: var(--muted) !important;
-	border: 1px solid var(--border) !important;
-	border-radius: 0.5rem;
-	padding: 0.5rem 0.75rem;
-	overflow-x: auto;
-	max-width: 100%;
+  background: oklch(from var(--muted) l c h / 0.34) !important;
+  border: 1px solid oklch(from var(--border) l c h / 0.95) !important;
+  border-radius: 0.625rem;
+  padding: 0.75rem 0.875rem;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .prose pre code {
-	background: var(--muted) !important;
-	border: none !important;
-	padding: 0;
-	font-size: 0.8125rem;
-	line-height: 1.6;
-	color: inherit;
+  background: transparent !important;
+  border: none !important;
+  padding: 0;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: inherit;
 }
 
 /* Inline code - Published content */
 .prose code:not(pre code) {
-	background: var(--muted) !important;
-	border: 1px solid var(--border) !important;
-	color: var(--foreground) !important;
-	padding: 0.5rem 0.75rem;
-	border-radius: 0.375rem;
-	font-size: 0.875em;
+  background: oklch(from var(--muted) l c h / 0.42) !important;
+  border: 1px solid oklch(from var(--border) l c h / 0.95) !important;
+  color: var(--foreground) !important;
+  padding: 0.12rem 0.35rem;
+  border-radius: 0.375rem;
+  font-family: var(--font-mono);
+  font-size: 0.875em;
 }
 
 /* Syntax highlighting - Vesper theme inspired */
@@ -332,26 +463,26 @@
 /* Light mode - muted version of Vesper */
 .hljs-comment,
 .hljs-quote {
-	color: #8b8b8b;
-	font-style: italic;
+  color: #8b8b8b;
+  font-style: italic;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-addition {
-	color: #6b6b6b;
+  color: #6b6b6b;
 }
 
 .hljs-string,
 .hljs-meta .hljs-string,
 .hljs-regexp {
-	color: #0d9488;
+  color: #0d9488;
 }
 
 .hljs-number,
 .hljs-literal,
 .hljs-type {
-	color: #c2410c;
+  color: #c2410c;
 }
 
 .hljs-title,
@@ -360,67 +491,67 @@
 .hljs-selector-id,
 .hljs-selector-class,
 .hljs-function {
-	color: #c2410c;
+  color: #c2410c;
 }
 
 .hljs-variable,
 .hljs-template-variable,
 .hljs-params {
-	color: var(--foreground);
+  color: var(--foreground);
 }
 
 .hljs-built_in,
 .hljs-tag {
-	color: #c2410c;
+  color: #c2410c;
 }
 
 .hljs-attr,
 .hljs-attribute {
-	color: #6b6b6b;
+  color: #6b6b6b;
 }
 
 .hljs-symbol,
 .hljs-bullet,
 .hljs-link {
-	color: #0d9488;
+  color: #0d9488;
 }
 
 .hljs-meta,
 .hljs-deletion {
-	color: #6b6b6b;
+  color: #6b6b6b;
 }
 
 .hljs-emphasis {
-	font-style: italic;
+  font-style: italic;
 }
 
 .hljs-strong {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 /* Dark mode - Vesper theme colors */
 .dark .hljs-comment,
 .dark .hljs-quote {
-	color: #8b8b8b;
-	font-style: italic;
+  color: #8b8b8b;
+  font-style: italic;
 }
 
 .dark .hljs-keyword,
 .dark .hljs-selector-tag,
 .dark .hljs-addition {
-	color: #a0a0a0;
+  color: #a0a0a0;
 }
 
 .dark .hljs-string,
 .dark .hljs-meta .hljs-string,
 .dark .hljs-regexp {
-	color: #99ffe4;
+  color: #99ffe4;
 }
 
 .dark .hljs-number,
 .dark .hljs-literal,
 .dark .hljs-type {
-	color: #77b9ff;
+  color: #77b9ff;
 }
 
 .dark .hljs-title,
@@ -429,32 +560,32 @@
 .dark .hljs-selector-id,
 .dark .hljs-selector-class,
 .dark .hljs-function {
-	color: #77b9ff;
+  color: #77b9ff;
 }
 
 .dark .hljs-variable,
 .dark .hljs-template-variable,
 .dark .hljs-params {
-	color: #fff;
+  color: #fff;
 }
 
 .dark .hljs-built_in,
 .dark .hljs-tag {
-	color: #77b9ff;
+  color: #77b9ff;
 }
 
 .dark .hljs-attr,
 .dark .hljs-attribute {
-	color: #a0a0a0;
+  color: #a0a0a0;
 }
 
 .dark .hljs-symbol,
 .dark .hljs-bullet,
 .dark .hljs-link {
-	color: #99ffe4;
+  color: #99ffe4;
 }
 
 .dark .hljs-meta,
 .dark .hljs-deletion {
-	color: #a0a0a0;
+  color: #a0a0a0;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -331,6 +331,18 @@
   border: 1px solid oklch(from var(--border) l c h / 0.95);
   border-radius: 0.625rem;
   margin: 1rem 0;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 0.75rem 0.875rem;
+}
+
+.markdown-prose :where(pre code) {
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.65;
+  padding: 0;
 }
 
 .link-text {


### PR DESCRIPTION
## What changed

This PR improves markdown editing and display for updates and comments.

It tightens the shared markdown typography, adds syntax highlighting for rendered code blocks, loads a dedicated mono font for code, and fixes toolbar state so formatting controls reflect the cursor position inside the editor.

## Why it changed

The markdown experience had a few gaps:

- headings were hard to distinguish
- paragraph spacing felt too loose
- code blocks were not highlighted consistently
- inline backticks could render as raw markdown in published content
- toolbar state was not reflecting the active formatting under the caret

## User impact

Users can now:

- see clearer heading hierarchy and more consistent paragraph spacing
- read inline code and fenced code blocks with stronger styling and a dedicated mono font
- get syntax highlighting on rendered code blocks without paying that cost for every render path up front
- see active inline and block formatting in the toolbar based on the current cursor position
- switch headings back to `Body` or between heading levels from the toolbar

## Root cause

The main editor-state bug was that the toolbar read formatting state from Tiptap, but React was not subscribed to editor selection and focus changes. Moving the caret inside the editor did not trigger a toolbar re-render, so active formatting indicators never updated.

## Validation

- `pnpm exec vitest run src/components/editor/format-content-for-display.test.ts`
- `pnpm typecheck`
- `pnpm build`
