### PR TITLE
Redesign update editor pages

### DIFF
--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -196,7 +196,7 @@ function EditUpdateRoute() {
               to="/@{$org}/$project/updates/$slug"
             >
               <ArrowLeft className="size-3.5" />
-              <span className="hidden sm:inline">Back</span>
+              <span className="sr-only sm:not-sr-only">Back</span>
             </Link>
             <Separator className="h-4" orientation="vertical" />
             <span className="text-sm font-medium text-muted-foreground">Edit Update</span>
@@ -252,7 +252,7 @@ function EditUpdateRoute() {
                     className={cn({
                       'select-none opacity-50 grayscale': visuallyDisabled,
                     })}
-                    disabled={saveMutation.isPending}
+                    disabled={visuallyDisabled}
                     size="sm"
                     type="submit"
                   >
@@ -341,6 +341,7 @@ function EditUpdateRoute() {
                           <Badge className="gap-1 pr-1" key={tag} variant="secondary">
                             {tag}
                             <button
+                              aria-label={`Remove tag ${tag}`}
                               className="ml-0.5 rounded-sm p-0.5 hover:bg-muted hover:text-destructive"
                               onClick={() =>
                                 field.handleChange((field.state.value || []).filter((value) => value !== tag))

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -191,12 +191,15 @@ function EditUpdateRoute() {
         <div className="container flex items-center justify-between gap-4 py-3">
           <div className="flex items-center gap-3">
             <Link
+              aria-label="Back to Update"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
               params={params}
               to="/@{$org}/$project/updates/$slug"
             >
               <ArrowLeft className="size-3.5" />
-              <span className="sr-only sm:not-sr-only">Back</span>
+              <span aria-hidden="true" className="hidden sm:inline">
+                Back
+              </span>
             </Link>
             <Separator className="h-4" orientation="vertical" />
             <span className="text-sm font-medium text-muted-foreground">Edit Update</span>

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 import { revalidateLogic, useForm } from '@tanstack/react-form';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
-import { FileText, X } from 'lucide-react';
+import { ArrowLeft, Image, LinkIcon, Settings2, Tag, Trash2, X } from 'lucide-react';
 
 import { MarkdownEditor, sanitizeEditorContent } from '@/components/editor';
 import { InlineAlert } from '@/components/inline-alert';
+import { SidebarSection } from '@/components/sidebar-section';
 import { Badge } from '@/components/ui/badge';
-import { Button, buttonVariants } from '@/components/ui/button';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input-shadcn';
 import {
   Select,
@@ -16,8 +17,10 @@ import {
   SelectPositioner,
   SelectTrigger,
 } from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
 import { authClient } from '@/lib/convex/auth-client';
 import { useCRPC } from '@/lib/convex/crpc';
+import { useSidebarState } from '@/lib/hooks/use-sidebar-state';
 import { cn } from '@/lib/utils';
 
 import { CategoryBadge, type UpdateCategory } from '../-components/category-badge';
@@ -25,6 +28,15 @@ import { CoverImageUpload } from '../-components/cover-image-upload';
 import { FeedbackSelector } from '../-components/feedback-selector';
 
 const UPDATE_CATEGORIES = ['changelog', 'article', 'announcement'] as const;
+
+const SIDEBAR_STORAGE_KEY = 'update-editor-sidebar-state';
+
+const DEFAULT_SIDEBAR_STATE = {
+  coverImage: true,
+  relatedFeedback: false,
+  settings: true,
+  tags: true,
+};
 
 export const Route = createFileRoute('/@{$org}/$project/updates/$slug/edit')({
   component: EditUpdateRoute,
@@ -37,6 +49,10 @@ function EditUpdateRoute() {
   const session = authClient.useSession();
   const [tagInput, setTagInput] = useState('');
   const [formError, setFormError] = useState('');
+  const { state: sidebarState, setSection: setSidebarSection } = useSidebarState(
+    SIDEBAR_STORAGE_KEY,
+    DEFAULT_SIDEBAR_STATE
+  );
 
   const projectQuery = useQuery(
     crpc.project.getDetails.queryOptions({
@@ -163,42 +179,258 @@ function EditUpdateRoute() {
   const isPublished = update.status === 'published';
 
   return (
-    <div className="container py-8">
-      <div className="mx-auto max-w-2xl">
-        <div className="mb-8 flex items-start justify-between gap-4">
-          <div className="flex items-start gap-4">
-            <div className="mt-1">
-              <FileText aria-hidden="true" className="size-8 text-primary dark:text-blue-300" />
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold">Edit Update</h1>
-              <p className="text-muted-foreground">
-                {isPublished ? 'This update is published.' : 'This update is a draft.'}
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
+    >
+      {/* Sticky header bar */}
+      <div className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur-sm supports-[backdrop-filter]:bg-background/80">
+        <div className="container flex items-center justify-between gap-4 py-3">
+          <div className="flex items-center gap-3">
+            <Link
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              params={params}
+              to="/@{$org}/$project/updates/$slug"
+            >
+              <ArrowLeft className="size-3.5" />
+              <span className="hidden sm:inline">Back</span>
+            </Link>
+            <Separator className="h-4" orientation="vertical" />
+            <span className="text-sm font-medium text-muted-foreground">Edit Update</span>
+            {isPublished ? (
+              <Badge className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400" variant="outline">
+                Published
+              </Badge>
+            ) : (
+              <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400" variant="outline">
+                Draft
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            {isPublished ? (
+              <Button
+                disabled={unpublishMutation.isPending}
+                onClick={() => unpublishMutation.mutate({ id: update.id })}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                {unpublishMutation.isPending ? 'Unpublishing...' : 'Unpublish'}
+              </Button>
+            ) : (
+              <Button
+                disabled={publishMutation.isPending}
+                onClick={() => publishMutation.mutate({ id: update.id })}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {publishMutation.isPending ? 'Publishing...' : 'Publish'}
+              </Button>
+            )}
+            <form.Subscribe
+              selector={(state) => ({
+                content: state.values.content,
+                isSubmitting: state.isSubmitting,
+                title: state.values.title,
+              })}
+            >
+              {({ content, isSubmitting, title }) => {
+                const visuallyDisabled =
+                  !title.trim() ||
+                  !sanitizeEditorContent(content) ||
+                  isSubmitting ||
+                  saveMutation.isPending;
+
+                return (
+                  <Button
+                    className={cn({
+                      'select-none opacity-50 grayscale': visuallyDisabled,
+                    })}
+                    disabled={saveMutation.isPending}
+                    size="sm"
+                    type="submit"
+                  >
+                    {saveMutation.isPending ? 'Saving...' : 'Save Changes'}
+                  </Button>
+                );
+              }}
+            </form.Subscribe>
+          </div>
+        </div>
+      </div>
+
+      {formError ? (
+        <div className="container pt-4">
+          <InlineAlert variant="danger">Unable to update: {formError}</InlineAlert>
+        </div>
+      ) : null}
+
+      {/* Two-column layout */}
+      <div className="container flex-1 grid-cols-12 gap-8 md:grid">
+        {/* Sidebar */}
+        <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
+          <div className="sticky top-16 flex flex-col gap-6 pl-8">
+            <SidebarSection
+              icon={<Settings2 className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('settings', open)}
+              open={sidebarState.settings}
+              title="Settings"
+            >
+              <form.Field name="category">
+                {(field) => (
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-muted-foreground">Category</label>
+                    <Select
+                      onValueChange={(value) => field.handleChange(value as UpdateCategory)}
+                      value={field.state.value}
+                    >
+                      <SelectTrigger className="w-full">
+                        <CategoryBadge category={field.state.value} />
+                      </SelectTrigger>
+                      <SelectPositioner>
+                        <SelectContent>
+                          {UPDATE_CATEGORIES.map((category) => (
+                            <SelectItem key={category} value={category}>
+                              <CategoryBadge category={category} />
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </SelectPositioner>
+                    </Select>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <SidebarSection
+              icon={<Image className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('coverImage', open)}
+              open={sidebarState.coverImage}
+              title="Cover Image"
+            >
+              <form.Field name="coverImageId">
+                {(field) => (
+                  <CoverImageUpload
+                    currentCoverImageUrl={updateData.coverImageUrl}
+                    onChange={(value) => field.handleChange(value)}
+                    onError={(message) => setFormError(message)}
+                    updateId={update.id}
+                  />
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <SidebarSection
+              icon={<Tag className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('tags', open)}
+              open={sidebarState.tags}
+              title="Tags"
+            >
+              <form.Field name="tags">
+                {(field) => (
+                  <div className="flex flex-col gap-3">
+                    {(field.state.value || []).length > 0 ? (
+                      <div className="flex flex-wrap gap-1.5">
+                        {(field.state.value || []).map((tag) => (
+                          <Badge className="gap-1 pr-1" key={tag} variant="secondary">
+                            {tag}
+                            <button
+                              className="ml-0.5 rounded-sm p-0.5 hover:bg-muted hover:text-destructive"
+                              onClick={() =>
+                                field.handleChange((field.state.value || []).filter((value) => value !== tag))
+                              }
+                              type="button"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="flex-1"
+                        onChange={(event) => setTagInput(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            addTag();
+                          }
+                        }}
+                        placeholder="Add tag..."
+                        value={tagInput}
+                      />
+                      <Button onClick={addTag} size="sm" type="button" variant="outline">
+                        Add
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <SidebarSection
+              icon={<LinkIcon className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('relatedFeedback', open)}
+              open={sidebarState.relatedFeedback}
+              title="Related Feedback"
+            >
+              <form.Field name="relatedFeedbackIds">
+                {(field) => (
+                  <div className="flex flex-col gap-2">
+                    <FeedbackSelector
+                      onChange={(ids) => field.handleChange(ids)}
+                      projectId={project.id}
+                      selectedIds={field.state.value}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Link feedback items addressed by this update.
+                    </p>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <Separator />
+
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                Danger Zone
               </p>
+              <Button
+                className="w-full"
+                disabled={deleteMutation.isPending}
+                onClick={() => {
+                  if (window.confirm('Are you sure you want to delete this update? This cannot be undone.')) {
+                    deleteMutation.mutate({ id: update.id });
+                  }
+                }}
+                size="sm"
+                type="button"
+                variant="destructive"
+              >
+                <Trash2 className="size-3.5" />
+                {deleteMutation.isPending ? 'Deleting...' : 'Delete Update'}
+              </Button>
             </div>
           </div>
-          <Link
-            className={cn(buttonVariants({ variant: 'outline' }))}
-            params={params}
-            to="/@{$org}/$project/updates/$slug"
-          >
-            Back to update
-          </Link>
         </div>
 
-        <form
-          className="flex flex-col gap-6"
-          onSubmit={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            void form.handleSubmit();
-          }}
-        >
+        {/* Main content area */}
+        <div className="flex flex-col gap-6 py-8 md:col-span-8">
           <form.Field name="title">
             {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Title</label>
+              <div className="flex flex-col gap-2 pt-6">
+                <label className="text-sm font-medium" htmlFor="update-title">Title</label>
                 <Input
+                  className="h-auto px-4 py-3 text-xl font-semibold tracking-tight md:text-2xl"
+                  id="update-title"
                   onChange={(event) => field.handleChange(event.target.value)}
                   placeholder="Update title..."
                   value={field.state.value}
@@ -207,49 +439,12 @@ function EditUpdateRoute() {
             )}
           </form.Field>
 
-          <form.Field name="category">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Category</label>
-                <Select
-                  onValueChange={(value) => field.handleChange(value as UpdateCategory)}
-                  value={field.state.value}
-                >
-                  <SelectTrigger className="w-48">
-                    <CategoryBadge category={field.state.value} />
-                  </SelectTrigger>
-                  <SelectPositioner>
-                    <SelectContent>
-                      {UPDATE_CATEGORIES.map((category) => (
-                        <SelectItem key={category} value={category}>
-                          <CategoryBadge category={category} />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </SelectPositioner>
-                </Select>
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="coverImageId">
-            {(field) => (
-              <CoverImageUpload
-                currentCoverImageUrl={updateData.coverImageUrl}
-                onChange={(value) => field.handleChange(value)}
-                onError={(message) => setFormError(message)}
-                updateId={update.id}
-              />
-            )}
-          </form.Field>
-
           <form.Field name="content">
             {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Content</label>
+              <div className="flex flex-col gap-2">
                 <MarkdownEditor
-                  maxHeight="600px"
-                  minHeight="200px"
+                  maxHeight="calc(100vh - 280px)"
+                  minHeight="400px"
                   onChange={(html) => field.handleChange(html)}
                   placeholder="Write your update content..."
                   value={field.state.value}
@@ -257,130 +452,8 @@ function EditUpdateRoute() {
               </div>
             )}
           </form.Field>
-
-          <form.Field name="tags">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Tags</label>
-                <div className="flex flex-wrap items-center gap-2">
-                  {(field.state.value || []).map((tag) => (
-                    <Badge className="gap-1" key={tag} variant="secondary">
-                      {tag}
-                      <button
-                        className="ml-1 hover:text-destructive"
-                        onClick={() =>
-                          field.handleChange((field.state.value || []).filter((value) => value !== tag))
-                        }
-                        type="button"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                  <div className="flex items-center gap-2">
-                    <Input
-                      className="w-32"
-                      onChange={(event) => setTagInput(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          event.preventDefault();
-                          addTag();
-                        }
-                      }}
-                      placeholder="Add tag..."
-                      value={tagInput}
-                    />
-                    <Button onClick={addTag} size="sm" type="button" variant="outline">
-                      Add
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="relatedFeedbackIds">
-            {(field) => (
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">Related Feedback</label>
-                <FeedbackSelector
-                  onChange={(ids) => field.handleChange(ids)}
-                  projectId={project.id}
-                  selectedIds={field.state.value}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Link feedback items that are addressed by this update.
-                </p>
-              </div>
-            )}
-          </form.Field>
-
-          {formError ? <InlineAlert variant="danger">Unable to update: {formError}</InlineAlert> : null}
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-              <form.Subscribe
-                selector={(state) => ({
-                  content: state.values.content,
-                  isSubmitting: state.isSubmitting,
-                  title: state.values.title,
-                })}
-              >
-                {({ content, isSubmitting, title }) => {
-                  const visuallyDisabled =
-                    !title.trim() ||
-                    !sanitizeEditorContent(content) ||
-                    isSubmitting ||
-                    saveMutation.isPending;
-
-                  return (
-                    <Button
-                      className={cn({
-                        'select-none opacity-50 grayscale': visuallyDisabled,
-                      })}
-                      disabled={saveMutation.isPending}
-                      type="submit"
-                    >
-                      {saveMutation.isPending ? 'Saving...' : 'Save Changes'}
-                    </Button>
-                  );
-                }}
-              </form.Subscribe>
-              {isPublished ? (
-                <Button
-                  disabled={unpublishMutation.isPending}
-                  onClick={() => unpublishMutation.mutate({ id: update.id })}
-                  type="button"
-                  variant="outline"
-                >
-                  {unpublishMutation.isPending ? 'Unpublishing...' : 'Unpublish'}
-                </Button>
-              ) : (
-                <Button
-                  disabled={publishMutation.isPending}
-                  onClick={() => publishMutation.mutate({ id: update.id })}
-                  type="button"
-                  variant="outline"
-                >
-                  {publishMutation.isPending ? 'Publishing...' : 'Publish'}
-                </Button>
-              )}
-            </div>
-            <Button
-              disabled={deleteMutation.isPending}
-              onClick={() => {
-                if (window.confirm('Are you sure you want to delete this update? This cannot be undone.')) {
-                  deleteMutation.mutate({ id: update.id });
-                }
-              }}
-              type="button"
-              variant="destructive"
-            >
-              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-            </Button>
-          </div>
-        </form>
+        </div>
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/routes/@{$org}/$project/updates/new/index.tsx
+++ b/src/routes/@{$org}/$project/updates/new/index.tsx
@@ -1,11 +1,12 @@
 import { useRef, useState } from 'react';
 import { revalidateLogic, useForm } from '@tanstack/react-form';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { createFileRoute, Navigate, useNavigate } from '@tanstack/react-router';
-import { FileText, X } from 'lucide-react';
+import { createFileRoute, Link, Navigate, useNavigate } from '@tanstack/react-router';
+import { ArrowLeft, LinkIcon, Settings2, Tag, X } from 'lucide-react';
 
 import { MarkdownEditor, sanitizeEditorContent } from '@/components/editor';
 import { InlineAlert } from '@/components/inline-alert';
+import { SidebarSection } from '@/components/sidebar-section';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input-shadcn';
@@ -16,14 +17,24 @@ import {
   SelectPositioner,
   SelectTrigger,
 } from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
 import { authClient } from '@/lib/convex/auth-client';
 import { useCRPC } from '@/lib/convex/crpc';
+import { useSidebarState } from '@/lib/hooks/use-sidebar-state';
 import { cn } from '@/lib/utils';
 
 import { CategoryBadge, type UpdateCategory } from '../-components/category-badge';
 import { FeedbackSelector } from '../-components/feedback-selector';
 
 const UPDATE_CATEGORIES = ['changelog', 'article', 'announcement'] as const;
+
+const SIDEBAR_STORAGE_KEY = 'update-new-sidebar-state';
+
+const DEFAULT_SIDEBAR_STATE = {
+  relatedFeedback: false,
+  settings: true,
+  tags: true,
+};
 
 export const Route = createFileRoute('/@{$org}/$project/updates/new/')({
   component: NewUpdateRoute,
@@ -37,6 +48,10 @@ function NewUpdateRoute() {
   const [tagInput, setTagInput] = useState('');
   const [formError, setFormError] = useState('');
   const pendingPublishRef = useRef<null | { id: string; slug: string }>(null);
+  const { state: sidebarState, setSection: setSidebarSection } = useSidebarState(
+    SIDEBAR_STORAGE_KEY,
+    DEFAULT_SIDEBAR_STATE
+  );
 
   const projectQuery = useQuery(
     crpc.project.getDetails.queryOptions({
@@ -156,136 +171,31 @@ function NewUpdateRoute() {
   };
 
   return (
-    <div className="container py-8">
-      <div className="mx-auto max-w-2xl">
-        <div className="mb-8 flex items-start gap-4">
-          <div className="mt-1">
-            <FileText aria-hidden="true" className="size-8 text-primary dark:text-blue-300" />
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void form.handleSubmit();
+      }}
+    >
+      {/* Sticky header bar */}
+      <div className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur-sm supports-[backdrop-filter]:bg-background/80">
+        <div className="container flex items-center justify-between gap-4 py-3">
+          <div className="flex items-center gap-3">
+            <Link
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              params={{ org: params.org, project: params.project }}
+              to="/@{$org}/$project/updates"
+            >
+              <ArrowLeft className="size-3.5" />
+              <span className="hidden sm:inline">Updates</span>
+            </Link>
+            <Separator className="h-4" orientation="vertical" />
+            <span className="text-sm font-medium text-muted-foreground">New Update</span>
+            <Badge className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400" variant="outline">
+              Draft
+            </Badge>
           </div>
-          <div>
-            <h1 className="text-2xl font-bold">Create Update</h1>
-            <p className="text-muted-foreground">Write a new update for your project.</p>
-          </div>
-        </div>
-        <form
-          className="flex flex-col gap-6"
-          onSubmit={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            void form.handleSubmit();
-          }}
-        >
-          <form.Field name="title">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Title</label>
-                <Input
-                  onChange={(event) => field.handleChange(event.target.value)}
-                  placeholder="Update title..."
-                  value={field.state.value}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="category">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Category</label>
-                <Select
-                  onValueChange={(value) => field.handleChange(value as UpdateCategory)}
-                  value={field.state.value}
-                >
-                  <SelectTrigger className="w-48">
-                    <CategoryBadge category={field.state.value} />
-                  </SelectTrigger>
-                  <SelectPositioner>
-                    <SelectContent>
-                      {UPDATE_CATEGORIES.map((category) => (
-                        <SelectItem key={category} value={category}>
-                          <CategoryBadge category={category} />
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </SelectPositioner>
-                </Select>
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="content">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Content</label>
-                <MarkdownEditor
-                  maxHeight="600px"
-                  minHeight="200px"
-                  onChange={(html) => field.handleChange(html)}
-                  placeholder="Write your update content..."
-                  value={field.state.value}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="tags">
-            {(field) => (
-              <div className="grid gap-2">
-                <label className="text-sm font-medium">Tags</label>
-                <div className="flex flex-wrap items-center gap-2">
-                  {(field.state.value || []).map((tag) => (
-                    <Badge className="gap-1" key={tag} variant="secondary">
-                      {tag}
-                      <button
-                        className="ml-1 hover:text-destructive"
-                        onClick={() =>
-                          field.handleChange((field.state.value || []).filter((value) => value !== tag))
-                        }
-                        type="button"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                  <div className="flex items-center gap-2">
-                    <Input
-                      className="w-32"
-                      onChange={(event) => setTagInput(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          event.preventDefault();
-                          addTag();
-                        }
-                      }}
-                      placeholder="Add tag..."
-                      value={tagInput}
-                    />
-                    <Button onClick={addTag} size="sm" type="button" variant="outline">
-                      Add
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="relatedFeedbackIds">
-            {(field) => (
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium">Related Feedback</label>
-                <FeedbackSelector
-                  onChange={(ids) => field.handleChange(ids)}
-                  projectId={project.id}
-                  selectedIds={field.state.value}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Link feedback items that are addressed by this update.
-                </p>
-              </div>
-            )}
-          </form.Field>
-
-          {formError ? <InlineAlert variant="danger">Unable to create update: {formError}</InlineAlert> : null}
 
           <div className="flex items-center gap-2">
             <form.Subscribe
@@ -311,6 +221,7 @@ function NewUpdateRoute() {
                         'select-none opacity-50 grayscale': savingDisabled,
                       })}
                       disabled={createMutation.isPending}
+                      size="sm"
                       type="submit"
                       variant="outline"
                     >
@@ -322,6 +233,7 @@ function NewUpdateRoute() {
                       })}
                       disabled={createMutation.isPending || publishMutation.isPending}
                       onClick={() => void publishFromDraft()}
+                      size="sm"
                       type="button"
                     >
                       {publishMutation.isPending ? 'Publishing...' : 'Publish'}
@@ -331,8 +243,158 @@ function NewUpdateRoute() {
               }}
             </form.Subscribe>
           </div>
-        </form>
+        </div>
       </div>
-    </div>
+
+      {formError ? (
+        <div className="container pt-4">
+          <InlineAlert variant="danger">Unable to create update: {formError}</InlineAlert>
+        </div>
+      ) : null}
+
+      {/* Two-column layout */}
+      <div className="container flex-1 grid-cols-12 gap-8 md:grid">
+        {/* Sidebar */}
+        <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
+          <div className="sticky top-16 flex flex-col gap-6 pl-8">
+            <SidebarSection
+              icon={<Settings2 className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('settings', open)}
+              open={sidebarState.settings}
+              title="Settings"
+            >
+              <form.Field name="category">
+                {(field) => (
+                  <div className="flex flex-col gap-2">
+                    <label className="text-sm text-muted-foreground">Category</label>
+                    <Select
+                      onValueChange={(value) => field.handleChange(value as UpdateCategory)}
+                      value={field.state.value}
+                    >
+                      <SelectTrigger className="w-full">
+                        <CategoryBadge category={field.state.value} />
+                      </SelectTrigger>
+                      <SelectPositioner>
+                        <SelectContent>
+                          {UPDATE_CATEGORIES.map((category) => (
+                            <SelectItem key={category} value={category}>
+                              <CategoryBadge category={category} />
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </SelectPositioner>
+                    </Select>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <SidebarSection
+              icon={<Tag className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('tags', open)}
+              open={sidebarState.tags}
+              title="Tags"
+            >
+              <form.Field name="tags">
+                {(field) => (
+                  <div className="flex flex-col gap-3">
+                    {(field.state.value || []).length > 0 ? (
+                      <div className="flex flex-wrap gap-1.5">
+                        {(field.state.value || []).map((tag) => (
+                          <Badge className="gap-1 pr-1" key={tag} variant="secondary">
+                            {tag}
+                            <button
+                              className="ml-0.5 rounded-sm p-0.5 hover:bg-muted hover:text-destructive"
+                              onClick={() =>
+                                field.handleChange((field.state.value || []).filter((value) => value !== tag))
+                              }
+                              type="button"
+                            >
+                              <X className="h-3 w-3" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div className="flex items-center gap-2">
+                      <Input
+                        className="flex-1"
+                        onChange={(event) => setTagInput(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            addTag();
+                          }
+                        }}
+                        placeholder="Add tag..."
+                        value={tagInput}
+                      />
+                      <Button onClick={addTag} size="sm" type="button" variant="outline">
+                        Add
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+
+            <SidebarSection
+              icon={<LinkIcon className="size-3.5" />}
+              onOpenChange={(open) => setSidebarSection('relatedFeedback', open)}
+              open={sidebarState.relatedFeedback}
+              title="Related Feedback"
+            >
+              <form.Field name="relatedFeedbackIds">
+                {(field) => (
+                  <div className="flex flex-col gap-2">
+                    <FeedbackSelector
+                      onChange={(ids) => field.handleChange(ids)}
+                      projectId={project.id}
+                      selectedIds={field.state.value}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Link feedback items addressed by this update.
+                    </p>
+                  </div>
+                )}
+              </form.Field>
+            </SidebarSection>
+          </div>
+        </div>
+
+        {/* Main content area */}
+        <div className="flex flex-col gap-6 py-8 md:col-span-8">
+          <form.Field name="title">
+            {(field) => (
+              <div className="flex flex-col gap-2 pt-6">
+                <label className="text-sm font-medium" htmlFor="update-title">Title</label>
+                <Input
+                  autoFocus
+                  className="h-auto px-4 py-3 text-xl font-semibold tracking-tight md:text-2xl"
+                  id="update-title"
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  placeholder="Update title..."
+                  value={field.state.value}
+                />
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="content">
+            {(field) => (
+              <div className="flex flex-col gap-2">
+                <MarkdownEditor
+                  maxHeight="calc(100vh - 280px)"
+                  minHeight="400px"
+                  onChange={(html) => field.handleChange(html)}
+                  placeholder="Write your update content..."
+                  value={field.state.value}
+                />
+              </div>
+            )}
+          </form.Field>
+        </div>
+      </div>
+    </form>
   );
 }

--- a/src/routes/@{$org}/$project/updates/new/index.tsx
+++ b/src/routes/@{$org}/$project/updates/new/index.tsx
@@ -188,7 +188,7 @@ function NewUpdateRoute() {
               to="/@{$org}/$project/updates"
             >
               <ArrowLeft className="size-3.5" />
-              <span className="sr-only sm:not-sr-only">Updates</span>
+              <span className="sr-only sm:not-sr-only">Back to Updates</span>
             </Link>
             <Separator className="h-4" orientation="vertical" />
             <span className="text-sm font-medium text-muted-foreground">New Update</span>

--- a/src/routes/@{$org}/$project/updates/new/index.tsx
+++ b/src/routes/@{$org}/$project/updates/new/index.tsx
@@ -183,12 +183,15 @@ function NewUpdateRoute() {
         <div className="container flex items-center justify-between gap-4 py-3">
           <div className="flex items-center gap-3">
             <Link
+              aria-label="Back to Updates"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
               params={{ org: params.org, project: params.project }}
               to="/@{$org}/$project/updates"
             >
               <ArrowLeft className="size-3.5" />
-              <span className="sr-only sm:not-sr-only">Back to Updates</span>
+              <span aria-hidden="true" className="hidden sm:inline">
+                Updates
+              </span>
             </Link>
             <Separator className="h-4" orientation="vertical" />
             <span className="text-sm font-medium text-muted-foreground">New Update</span>

--- a/src/routes/@{$org}/$project/updates/new/index.tsx
+++ b/src/routes/@{$org}/$project/updates/new/index.tsx
@@ -188,7 +188,7 @@ function NewUpdateRoute() {
               to="/@{$org}/$project/updates"
             >
               <ArrowLeft className="size-3.5" />
-              <span className="hidden sm:inline">Updates</span>
+              <span className="sr-only sm:not-sr-only">Updates</span>
             </Link>
             <Separator className="h-4" orientation="vertical" />
             <span className="text-sm font-medium text-muted-foreground">New Update</span>
@@ -220,7 +220,7 @@ function NewUpdateRoute() {
                       className={cn({
                         'select-none opacity-50 grayscale': savingDisabled,
                       })}
-                      disabled={createMutation.isPending}
+                      disabled={savingDisabled}
                       size="sm"
                       type="submit"
                       variant="outline"
@@ -231,7 +231,7 @@ function NewUpdateRoute() {
                       className={cn({
                         'select-none opacity-50 grayscale': publishingDisabled,
                       })}
-                      disabled={createMutation.isPending || publishMutation.isPending}
+                      disabled={publishingDisabled}
                       onClick={() => void publishFromDraft()}
                       size="sm"
                       type="button"
@@ -304,6 +304,7 @@ function NewUpdateRoute() {
                           <Badge className="gap-1 pr-1" key={tag} variant="secondary">
                             {tag}
                             <button
+                              aria-label={`Remove tag ${tag}`}
                               className="ml-0.5 rounded-sm p-0.5 hover:bg-muted hover:text-destructive"
                               onClick={() =>
                                 field.handleChange((field.state.value || []).filter((value) => value !== tag))


### PR DESCRIPTION
## Summary
- Redesigns both the **new update** and **edit update** pages from a basic single-column form into a professional CMS-style editor layout
- Adds a **sticky header bar** with back navigation, status badge (Draft/Published), and primary actions (Save, Publish/Unpublish)
- Introduces a **two-column grid layout** (8 col content + 4 col sidebar) matching the existing update detail page's design language
- Moves metadata fields (category, cover image, tags, related feedback) into **collapsible sidebar sections** using `SidebarSection` + `useSidebarState` for persistent open/close state
- Uses the standard `Input` component for the title field with proper label, focus ring, and accessibility support
- Isolates the delete action into a "Danger Zone" section in the sidebar (edit page)

## Test plan
- [ ] Navigate to an existing update and click "Edit Update" — verify the two-column layout renders with sticky header
- [ ] Create a new update via "New Update" — verify the same layout with Draft badge and Save/Publish actions
- [ ] Test title input is visible, focusable, and shows focus ring on keyboard navigation
- [ ] Test sidebar sections collapse/expand and persist state across page navigations
- [ ] Test all actions: Save, Publish, Unpublish, Delete
- [ ] Verify responsive behavior on mobile (sidebar stacks above content)
- [ ] Verify dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)