### PR TITLE
[codex] Fix async form defaults and add CDP helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview:cleanup:stale-cloudflare": "node scripts/cleanup-stale-cloudflare-previews.mjs",
     "preview:cleanup:convex": "node scripts/cleanup-convex-preview.mjs",
     "preview:cleanup:stale-convex": "node scripts/cleanup-stale-convex-previews.mjs",
+    "dev:chrome-cdp": "scripts/dev-chrome-cdp.sh",
     "cf-typegen": "wrangler types",
     "preview": "vite preview",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preview:cleanup:stale-cloudflare": "node scripts/cleanup-stale-cloudflare-previews.mjs",
     "preview:cleanup:convex": "node scripts/cleanup-convex-preview.mjs",
     "preview:cleanup:stale-convex": "node scripts/cleanup-stale-convex-previews.mjs",
-    "dev:chrome-cdp": "scripts/dev-chrome-cdp.sh",
+    "dev:chrome-cdp": "bash scripts/dev-chrome-cdp.sh",
     "cf-typegen": "wrangler types",
     "preview": "vite preview",
     "test": "vitest run",

--- a/scripts/dev-chrome-cdp.sh
+++ b/scripts/dev-chrome-cdp.sh
@@ -11,10 +11,30 @@ fi
 
 mkdir -p "$CDP_PROFILE"
 
-open -na "Google Chrome" --args \
-  --remote-debugging-port="$CDP_PORT" \
-  --user-data-dir="$CDP_PROFILE" \
-  "${1:-$DEFAULT_URL}"
+URL="${1:-$DEFAULT_URL}"
+ARGS=(
+  "--remote-debugging-port=$CDP_PORT"
+  "--user-data-dir=$CDP_PROFILE"
+  "$URL"
+)
+
+if [[ "$OSTYPE" == "darwin"* ]] && command -v open >/dev/null 2>&1; then
+  open -na "Google Chrome" --args "${ARGS[@]}"
+elif command -v google-chrome >/dev/null 2>&1; then
+  google-chrome "${ARGS[@]}" >/dev/null 2>&1 &
+elif command -v chromium >/dev/null 2>&1; then
+  chromium "${ARGS[@]}" >/dev/null 2>&1 &
+elif command -v chromium-browser >/dev/null 2>&1; then
+  chromium-browser "${ARGS[@]}" >/dev/null 2>&1 &
+else
+  cat >&2 <<EOF
+Unable to launch a CDP browser.
+
+Install Google Chrome or Chromium, or launch one manually with:
+  --remote-debugging-port=$CDP_PORT --user-data-dir="$CDP_PROFILE"
+EOF
+  exit 1
+fi
 
 cat <<EOF
 Chrome CDP launched.

--- a/scripts/dev-chrome-cdp.sh
+++ b/scripts/dev-chrome-cdp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CDP_PORT="${CDP_PORT:-9222}"
+CDP_PROFILE="${CDP_PROFILE:-$HOME/.kino/chrome-cdp-profile}"
+DEFAULT_URL="${DEFAULT_URL:-https://sidebar-toggle-data-loss.kino.localhost:1355}"
+
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+mkdir -p "$CDP_PROFILE"
+
+open -na "Google Chrome" --args \
+  --remote-debugging-port="$CDP_PORT" \
+  --user-data-dir="$CDP_PROFILE" \
+  "${1:-$DEFAULT_URL}"
+
+cat <<EOF
+Chrome CDP launched.
+
+Profile: $CDP_PROFILE
+Version: http://localhost:$CDP_PORT/json/version
+Targets: http://localhost:$CDP_PORT/json/list
+EOF

--- a/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
@@ -62,7 +62,12 @@ function EditBoardRoute() {
       name: boardQuery.data?.name ?? '',
       slug: boardQuery.data?.slug ?? '',
     }),
-    [boardQuery.data]
+    [
+      boardQuery.data?.description,
+      boardQuery.data?.id,
+      boardQuery.data?.name,
+      boardQuery.data?.slug,
+    ]
   );
 
   const form = useForm({

--- a/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/edit.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useForm } from '@tanstack/react-form';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -56,12 +56,17 @@ function EditBoardRoute() {
     })
   );
 
+  const formDefaultValues = useMemo(
+    () => ({
+      description: boardQuery.data?.description ?? '',
+      name: boardQuery.data?.name ?? '',
+      slug: boardQuery.data?.slug ?? '',
+    }),
+    [boardQuery.data]
+  );
+
   const form = useForm({
-    defaultValues: {
-      description: '',
-      name: '',
-      slug: '',
-    },
+    defaultValues: formDefaultValues,
     onSubmit: async ({ value }) => {
       if (!boardQuery.data) return;
 
@@ -75,15 +80,6 @@ function EditBoardRoute() {
       });
     },
   });
-
-  useEffect(() => {
-    if (!boardQuery.data) return;
-    form.reset({
-      description: boardQuery.data.description ?? '',
-      name: boardQuery.data.name,
-      slug: boardQuery.data.slug,
-    });
-  }, [boardQuery.data, form]);
 
   if (!projectQuery.data?.permissions.canEdit) {
     return (

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -119,6 +119,14 @@ function EditUpdateRoute() {
 
   const updateData = updateQuery.data;
   const update = updateData?.update;
+  const relatedFeedbackIdsKey = useMemo(
+    () => JSON.stringify((update?.relatedFeedbackIds ?? []).map(String)),
+    [update?.relatedFeedbackIds]
+  );
+  const tagsKey = useMemo(
+    () => JSON.stringify((update?.tags ?? []).map(String)),
+    [update?.tags]
+  );
   const formDefaultValues = useMemo<UpdateFormValues>(
     () => ({
       category: (update?.category ?? 'changelog') as UpdateCategory,
@@ -128,7 +136,15 @@ function EditUpdateRoute() {
       tags: (update?.tags ?? []).map(String),
       title: update?.title ?? '',
     }),
-    [update]
+    [
+      relatedFeedbackIdsKey,
+      tagsKey,
+      update?.category,
+      update?.content,
+      update?.coverImageId,
+      update?.id,
+      update?.title,
+    ]
   );
 
   const form = useForm({

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { revalidateLogic, useForm } from '@tanstack/react-form';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -28,6 +28,14 @@ import { CoverImageUpload } from '../-components/cover-image-upload';
 import { FeedbackSelector } from '../-components/feedback-selector';
 
 const UPDATE_CATEGORIES = ['changelog', 'article', 'announcement'] as const;
+type UpdateFormValues = {
+  category: UpdateCategory;
+  content: string;
+  coverImageId: string | null;
+  relatedFeedbackIds: string[];
+  tags: string[];
+  title: string;
+};
 
 const SIDEBAR_STORAGE_KEY = 'update-editor-sidebar-state';
 
@@ -111,16 +119,20 @@ function EditUpdateRoute() {
 
   const updateData = updateQuery.data;
   const update = updateData?.update;
+  const formDefaultValues = useMemo<UpdateFormValues>(
+    () => ({
+      category: (update?.category ?? 'changelog') as UpdateCategory,
+      content: update?.content ?? '',
+      coverImageId: update?.coverImageId ?? null,
+      relatedFeedbackIds: (update?.relatedFeedbackIds ?? []).map(String),
+      tags: (update?.tags ?? []).map(String),
+      title: update?.title ?? '',
+    }),
+    [update]
+  );
 
   const form = useForm({
-    defaultValues: {
-      category: 'changelog' as UpdateCategory,
-      content: '',
-      coverImageId: null as string | null,
-      relatedFeedbackIds: [] as string[],
-      tags: [] as string[],
-      title: '',
-    },
+    defaultValues: formDefaultValues,
     onSubmit: async ({ value }) => {
       if (!update) return;
       setFormError('');
@@ -139,18 +151,6 @@ function EditUpdateRoute() {
       modeAfterSubmission: 'change',
     }),
   });
-
-  useEffect(() => {
-    if (!update) return;
-    form.reset({
-      category: update.category,
-      content: update.content,
-      coverImageId: update.coverImageId ?? null,
-      relatedFeedbackIds: (update.relatedFeedbackIds ?? []).map(String),
-      tags: update.tags ?? [],
-      title: update.title,
-    });
-  }, [form, update?.id]);
 
   if (!session.data?.user) {
     return <InlineAlert variant="warning">Sign in to edit updates.</InlineAlert>;

--- a/src/routes/@{$org}/edit/index.tsx
+++ b/src/routes/@{$org}/edit/index.tsx
@@ -42,7 +42,7 @@ function EditOrganizationRoute() {
       name: org?.name ?? '',
       slug: org?.slug ?? '',
     }),
-    [org]
+    [org?.name, org?.slug]
   );
 
   const form = useForm({

--- a/src/routes/@{$org}/edit/index.tsx
+++ b/src/routes/@{$org}/edit/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useForm } from '@tanstack/react-form';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -36,11 +36,17 @@ function EditOrganizationRoute() {
     })
   );
 
+  const org = orgQuery.data?.org;
+  const formDefaultValues = useMemo(
+    () => ({
+      name: org?.name ?? '',
+      slug: org?.slug ?? '',
+    }),
+    [org]
+  );
+
   const form = useForm({
-    defaultValues: {
-      name: '',
-      slug: '',
-    },
+    defaultValues: formDefaultValues,
     onSubmit: async ({ value }) => {
       const org = orgQuery.data?.org;
       if (!org) return;
@@ -52,16 +58,6 @@ function EditOrganizationRoute() {
       });
     },
   });
-
-  const org = orgQuery.data?.org;
-
-  useEffect(() => {
-    if (!org) return;
-    form.reset({
-      name: org.name,
-      slug: org.slug,
-    });
-  }, [form, org?._id]);
 
   if (orgQuery.isLoading) {
     return null;

--- a/src/routes/profile/settings/index.tsx
+++ b/src/routes/profile/settings/index.tsx
@@ -68,7 +68,7 @@ function AuthenticatedProfileSettingsRoute() {
       name: profile?.name ?? "",
       username: profile?.username ?? "",
     }),
-    [profile]
+    [profile?.name, profile?.username]
   )
 
   const form = useForm({

--- a/src/routes/profile/settings/index.tsx
+++ b/src/routes/profile/settings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useMemo, useState } from "react"
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query"
 import { useForm } from "@tanstack/react-form"
 import {
@@ -15,6 +15,12 @@ import { Input } from "@/components/ui/input-shadcn"
 import { useCRPC } from "@/lib/convex/crpc"
 import { crpcServer } from "@/lib/convex/crpc-server"
 import { cn } from "@/lib/utils"
+
+type ProfileSettingsFormValues = {
+  avatarFile: File | null
+  name: string
+  username: string
+}
 
 export const Route = createFileRoute("/profile/settings/")({
   loader: async ({ context }) => {
@@ -56,13 +62,17 @@ function AuthenticatedProfileSettingsRoute() {
     crpc.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
   )
   const profile = profileQuery.data
+  const formDefaultValues = useMemo<ProfileSettingsFormValues>(
+    () => ({
+      avatarFile: null,
+      name: profile?.name ?? "",
+      username: profile?.username ?? "",
+    }),
+    [profile]
+  )
 
   const form = useForm({
-    defaultValues: {
-      avatarFile: null as File | null,
-      name: "",
-      username: "",
-    },
+    defaultValues: formDefaultValues,
     onSubmit: async ({ value, formApi }) => {
       if (!profile) return
       setFormError(null)
@@ -94,13 +104,14 @@ function AuthenticatedProfileSettingsRoute() {
             username: value.username,
           },
         })
+        const refreshedProfile = (await profileQuery.refetch()).data
 
         formApi.reset({
           avatarFile: null,
-          name: updatedProfile.name ?? value.name,
-          username: updatedProfile.username ?? value.username,
+          name: refreshedProfile?.name ?? updatedProfile.name ?? value.name,
+          username:
+            refreshedProfile?.username ?? updatedProfile.username ?? value.username,
         })
-        await profileQuery.refetch()
       } catch (error) {
         setFormError(
           error instanceof Error ? error.message : "Unable to update profile"
@@ -108,15 +119,6 @@ function AuthenticatedProfileSettingsRoute() {
       }
     },
   })
-
-  useEffect(() => {
-    if (!profile) return
-    form.reset({
-      avatarFile: null,
-      name: profile.name ?? "",
-      username: profile.username ?? "",
-    })
-  }, [form, profile?.id, profile?.name, profile?.username])
 
   if (!profile) {
     return null


### PR DESCRIPTION
## Summary

- Fix fetched-data edit forms so TanStack Form receives loaded data as `defaultValues` instead of empty defaults plus an effect-driven reset.
- Apply the pattern to the update editor, organization edit, profile settings, and feedback board edit forms.
- Add `pnpm run dev:chrome-cdp` to launch a persistent, CDP-enabled Chrome profile for UI debugging.

## Root Cause

TanStack Form updates its internal values when `defaultValues` change and the form is still untouched. The update editor was initialized with empty defaults, then reset with loaded update data in an effect. A later unrelated rerender, such as toggling a sidebar section, passed the empty defaults again and reset the untouched form back to blank values.

## Validation

- `pnpm run typecheck`
- `pnpm test`
- `pnpm run build`
- CDP browser repro on the update editor: clicking the `TAGS` sidebar toggle keeps the title, editor content, and Save state intact after the fix.

## Notes

The build still reports the existing large chunk warning.