### PR TITLE
Improve responsive layouts across app flows

### DIFF
--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -331,7 +331,7 @@ function FeedbackDetailRoute() {
   return (
     <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
       <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
-        <div className="sticky top-4 flex flex-col gap-6 pl-8">
+        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
           <div>
             <div className="flex items-center gap-3">
               <UpvoteButton

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -329,8 +329,8 @@ function FeedbackDetailRoute() {
   )
 
   return (
-    <div className="container flex-1 grid-cols-12 gap-8 md:grid">
-      <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
+    <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+      <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
         <div className="sticky top-4 flex flex-col gap-6 pl-8">
           <div>
             <div className="flex items-center gap-3">

--- a/src/routes/@{$org}/$project/feedback/boards/$board/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/$board/index.tsx
@@ -36,8 +36,8 @@ function BoardDetailRoute() {
   const board = boardQuery.data;
 
   return (
-    <div className="container">
-      <pre>
+    <div className="container py-6">
+      <pre className="overflow-x-auto rounded-lg border bg-muted p-4 text-xs">
         <code>{JSON.stringify(board, null, 2)}</code>
       </pre>
     </div>

--- a/src/routes/@{$org}/$project/feedback/boards/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/boards/index.tsx
@@ -52,13 +52,13 @@ function BoardsIndexRoute() {
   return (
     <div className="flex flex-1 flex-col">
       <div className="overflow-hidden border-b bg-muted/50 pt-12 pb-6">
-        <div className="container relative flex items-center justify-between">
+        <div className="container relative flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="relative">
-            <h1 className="relative z-10 flex items-center gap-2 text-3xl font-bold">
+            <h1 className="relative z-10 flex flex-wrap items-center gap-2 text-2xl font-bold md:text-3xl">
               <span className="text-muted-foreground">Feedback</span>
               <VArrowRight className="text-muted-foreground" size="20px" /> Boards
             </h1>
-            <h1 className="pointer-events-none absolute top-10 scale-[2.5] text-3xl font-bold opacity-50 blur-xl select-none">
+            <h1 className="pointer-events-none absolute top-10 hidden scale-[2.5] text-3xl font-bold opacity-50 blur-xl select-none md:flex md:items-center md:gap-2">
               <span className="text-muted-foreground">Feedback</span>
               <VArrowRight className="text-muted-foreground" size="20px" /> Boards
             </h1>

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -242,10 +242,10 @@ function FeedbackListRoute() {
 
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
-      <div className="flex-1 grid-cols-12 gap-8 md:grid">
-        <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-3">
+      <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+        <div className="order-last py-6 md:col-span-3 md:border-l md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="border-b pb-6 pl-6">
+            <div className="border-b pb-6 md:pl-6">
               <Button asChild className="w-full" size="lg">
                 <Link
                   params={{ org: orgSlug, project: projectSlug }}
@@ -256,7 +256,7 @@ function FeedbackListRoute() {
               </Button>
             </div>
             <div className="mt-4">
-              <div className="border-b pb-6 pl-6">
+              <div className="border-b pb-6 md:pl-6">
                 <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                   Boards
                 </h2>
@@ -265,7 +265,7 @@ function FeedbackListRoute() {
                 </div>
               </div>
               {projectData.permissions.canEdit ? (
-                <div className="mt-6 pb-6 pl-6">
+                <div className="mt-6 pb-6 md:pl-6">
                   <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                     Options
                   </h2>

--- a/src/routes/@{$org}/$project/updates/$slug/edit.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/edit.tsx
@@ -237,8 +237,8 @@ function EditUpdateRoute() {
                 Back
               </span>
             </Link>
-            <Separator className="h-4" orientation="vertical" />
-            <span className="text-sm font-medium text-muted-foreground">
+            <Separator className="hidden h-4 sm:block" orientation="vertical" />
+            <span className="hidden text-sm font-medium text-muted-foreground sm:inline">
               Edit Update
             </span>
             {isPublished ? (
@@ -321,10 +321,10 @@ function EditUpdateRoute() {
       ) : null}
 
       {/* Two-column layout */}
-      <div className="container flex-1 grid-cols-12 gap-8 md:grid">
+      <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
         {/* Sidebar */}
-        <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
-          <div className="sticky top-14 flex flex-col gap-6 pl-8">
+        <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
+          <div className="sticky top-14 flex flex-col gap-6 md:pl-8">
             <SidebarSection
               icon={<Settings2 className="size-3.5" />}
               onOpenChange={(open) => setSidebarSection("settings", open)}

--- a/src/routes/@{$org}/$project/updates/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/index.tsx
@@ -224,9 +224,9 @@ function UpdateDetailRoute() {
   }
 
   return (
-    <div className="container flex-1 grid-cols-12 gap-8 md:grid">
-      <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-4">
-        <div className="sticky top-4 flex flex-col gap-6 pl-8">
+    <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+      <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
+        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
           <style>{heartPopKeyframes}</style>
 
           <div className="flex items-center justify-between">

--- a/src/routes/@{$org}/$project/updates/index.tsx
+++ b/src/routes/@{$org}/$project/updates/index.tsx
@@ -96,10 +96,10 @@ function UpdatesListRoute() {
 
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
-      <div className="flex-1 grid-cols-12 gap-8 md:grid">
-        <div className="order-first border-l border-border/75 py-6 md:order-last md:col-span-3">
+      <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+        <div className="order-last py-6 md:col-span-3 md:border-l md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="pb-6 pl-6">
+            <div className="pb-6 md:pl-6">
               <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                 Categories
               </h2>
@@ -108,7 +108,7 @@ function UpdatesListRoute() {
               </div>
             </div>
             {canEdit ? (
-              <div className="border-t pt-6 pl-6">
+              <div className="border-t pt-6 md:pl-6">
                 <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                   Actions
                 </h2>

--- a/src/routes/@{$org}/-components/main-nav.tsx
+++ b/src/routes/@{$org}/-components/main-nav.tsx
@@ -86,7 +86,9 @@ export const MainNav = ({ children, isUserPending = false, user }: MainNavProps)
 						<div className='flex min-w-0 shrink-0 items-center gap-3'>
 							<div className='flex items-center gap-2'>
 								<div className='flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-primary'>
-									<span className='text-sm font-bold text-primary-foreground'>K</span>
+									<span aria-hidden='true' className='text-sm font-bold text-primary-foreground'>
+										K
+									</span>
 									<span className='sr-only'>Kino</span>
 								</div>
 								{!!orgSlug && (

--- a/src/routes/@{$org}/-components/main-nav.tsx
+++ b/src/routes/@{$org}/-components/main-nav.tsx
@@ -87,6 +87,7 @@ export const MainNav = ({ children, isUserPending = false, user }: MainNavProps)
 							<div className='flex items-center gap-2'>
 								<div className='flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-primary'>
 									<span className='text-sm font-bold text-primary-foreground'>K</span>
+									<span className='sr-only'>Kino</span>
 								</div>
 								{!!orgSlug && (
 									<div className='-ml-3 flex h-8 w-8 items-center justify-center rounded-full bg-foreground ring-2 ring-background'>

--- a/src/routes/@{$org}/-components/main-nav.tsx
+++ b/src/routes/@{$org}/-components/main-nav.tsx
@@ -86,8 +86,7 @@ export const MainNav = ({ children, isUserPending = false, user }: MainNavProps)
 						<div className='flex min-w-0 shrink-0 items-center gap-3'>
 							<div className='flex items-center gap-2'>
 								<div className='flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-primary'>
-									<img className='mt-0.4 mr-0.5' src='/kino-blue.webp' alt='Kino logo' />
-									{/* <span className='text-sm font-bold text-primary-foreground'>K</span> */}
+									<span className='text-sm font-bold text-primary-foreground'>K</span>
 								</div>
 								{!!orgSlug && (
 									<div className='-ml-3 flex h-8 w-8 items-center justify-center rounded-full bg-foreground ring-2 ring-background'>

--- a/src/routes/@{$org}/create-project/index.tsx
+++ b/src/routes/@{$org}/create-project/index.tsx
@@ -89,8 +89,8 @@ function CreateProjectRoute() {
   return (
     <div className="flex flex-auto flex-col">
       <div className="container flex flex-auto flex-col">
-        <div className="grid flex-1 grid-cols-12">
-          <div className="col-span-3 border-r">
+        <div className="grid flex-1 grid-cols-1 md:grid-cols-12">
+          <div className="col-span-3 hidden border-r md:block">
             <form.Subscribe selector={(state) => state.values}>
               {(values) => (
                 <div className="relative flex flex-col pr-6">
@@ -133,8 +133,8 @@ function CreateProjectRoute() {
               )}
             </form.Subscribe>
           </div>
-          <div className="col-span-9 p-6 md:p-12">
-            <h1 className="inline-flex flex-wrap items-center gap-y-1 text-3xl font-bold">
+          <div className="col-span-9 p-4 sm:p-6 md:p-12">
+            <h1 className="inline-flex flex-wrap items-center gap-y-1 text-2xl font-bold md:text-3xl">
               <span className="mr-2 inline-block">Create a new project for</span>
               <span className="inline-flex items-center gap-2 rounded-lg px-2 text-foreground">
                 <Avatar className="size-6 rounded-full border border-primary">
@@ -188,10 +188,12 @@ function CreateProjectRoute() {
                         </p>
                         <div className="flex items-stretch">
                           <div className="flex items-center rounded-l-lg border-y border-l border-border bg-muted px-3 text-sm">
-                            <span className="text-muted-foreground">usekino.com/@{params.org}/</span>
+                            <span className="text-muted-foreground">
+                              <span className="hidden sm:inline">usekino.com/</span>@{params.org}/
+                            </span>
                           </div>
                           <Input
-                            className="rounded-l-none"
+                            className="min-w-0 rounded-l-none"
                             disabled={!enabled}
                             onChange={(event) => field.handleChange(event.target.value)}
                             value={field.state.value}
@@ -213,7 +215,7 @@ function CreateProjectRoute() {
                           disabled={!enabled}
                           onValueChange={(value) => field.handleChange(value as 'public' | 'private')}
                         >
-                          <SelectTrigger className="w-48">
+                          <SelectTrigger className="w-full sm:w-48">
                             <SelectValue placeholder="Select visibility" />
                           </SelectTrigger>
                           <SelectContent>

--- a/src/routes/@{$org}/create-project/index.tsx
+++ b/src/routes/@{$org}/create-project/index.tsx
@@ -90,7 +90,7 @@ function CreateProjectRoute() {
     <div className="flex flex-auto flex-col">
       <div className="container flex flex-auto flex-col">
         <div className="grid flex-1 grid-cols-1 md:grid-cols-12">
-          <div className="col-span-3 hidden border-r md:block">
+          <div className="hidden border-r md:col-span-3 md:block">
             <form.Subscribe selector={(state) => state.values}>
               {(values) => (
                 <div className="relative flex flex-col pr-6">
@@ -133,7 +133,7 @@ function CreateProjectRoute() {
               )}
             </form.Subscribe>
           </div>
-          <div className="col-span-9 p-4 sm:p-6 md:p-12">
+          <div className="p-4 sm:p-6 md:col-span-9 md:p-12">
             <h1 className="inline-flex flex-wrap items-center gap-y-1 text-2xl font-bold md:text-3xl">
               <span className="mr-2 inline-block">Create a new project for</span>
               <span className="inline-flex items-center gap-2 rounded-lg px-2 text-foreground">
@@ -184,7 +184,7 @@ function CreateProjectRoute() {
                       <div className="flex flex-1 flex-col gap-2">
                         <label className="text-sm font-medium">Project Slug</label>
                         <p className="text-sm text-muted-foreground">
-                          Will be be used in URL of your project. Must be unique to your organization.
+                          Will be used in URL of your project. Must be unique to your organization.
                         </p>
                         <div className="flex items-stretch">
                           <div className="flex items-center rounded-l-lg border-y border-l border-border bg-muted px-3 text-sm">

--- a/src/routes/create/team/index.tsx
+++ b/src/routes/create/team/index.tsx
@@ -154,7 +154,7 @@ function AuthenticatedCreateTeamRoute() {
                       }
                     >
                       <SelectTrigger className="w-full sm:w-48">
-                        <SelectValue placeholder="Sort by..." />
+                        <SelectValue placeholder="Select visibility" />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectItem value="public">Public</SelectItem>

--- a/src/routes/create/team/index.tsx
+++ b/src/routes/create/team/index.tsx
@@ -88,7 +88,7 @@ function AuthenticatedCreateTeamRoute() {
   return (
     <div className="relative w-full">
       <div className="absolute top-0 right-0 left-0 z-0 h-64 w-full bg-linear-to-t from-background to-muted" />
-      <div className="relative z-10 mx-auto max-w-2xl px-10 py-12">
+      <div className="relative z-10 mx-auto max-w-2xl px-4 py-12 sm:px-6 md:px-10">
         <div>
           <h1 className="text-3xl font-bold">Create a team</h1>
           {!underLimit ? (
@@ -153,7 +153,7 @@ function AuthenticatedCreateTeamRoute() {
                         field.handleChange(value as "public" | "private")
                       }
                     >
-                      <SelectTrigger className="w-48">
+                      <SelectTrigger className="w-full sm:w-48">
                         <SelectValue placeholder="Sort by..." />
                       </SelectTrigger>
                       <SelectContent>


### PR DESCRIPTION
## What changed

- improved mobile and tablet layouts across the feedback and updates routes by switching sidebar-heavy pages to stack first on smaller screens
- tightened responsive spacing and controls on the create team and create project flows so form fields and selectors fit smaller viewports cleanly
- simplified the main nav brand mark to a text fallback and made the feedback board debug view easier to read on narrow screens

## Why it changed

- several product routes were optimized for desktop grid layouts and had left-padding, borders, and fixed-width controls that degraded the experience on smaller screens
- these updates make the affected pages usable without horizontal crowding while preserving the existing desktop structure

## Follow-up and test notes

- validated with `pnpm typecheck`
- no automated UI or browser checks were run in this pass
