### PR TITLE
Simplify project page headings and sidebar layout

### DIFF
--- a/src/routes/@{$org}/$project/chat/index.tsx
+++ b/src/routes/@{$org}/$project/chat/index.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import Chat from '@/icons/chat';
-
 export const Route = createFileRoute('/@{$org}/$project/chat/')({
   component: PlaceholderPage,
 });
@@ -9,13 +7,6 @@ export const Route = createFileRoute('/@{$org}/$project/chat/')({
 function PlaceholderPage() {
   return (
     <div className="container py-10">
-      <div className="flex items-start gap-3 border-b pb-6">
-        <Chat className="mt-1 text-muted-foreground" size="28px" />
-        <div className="space-y-1">
-          <h1 className="text-3xl font-bold">Chat</h1>
-          <p className="text-muted-foreground">This area remained a placeholder in the previous app.</p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/routes/@{$org}/$project/discussions/index.tsx
+++ b/src/routes/@{$org}/$project/discussions/index.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import Interview from '@/icons/interview';
-
 export const Route = createFileRoute('/@{$org}/$project/discussions/')({
   component: PlaceholderPage,
 });
@@ -9,13 +7,6 @@ export const Route = createFileRoute('/@{$org}/$project/discussions/')({
 function PlaceholderPage() {
   return (
     <div className="container py-10">
-      <div className="flex items-start gap-3 border-b pb-6">
-        <Interview className="mt-1 text-muted-foreground" size="28px" />
-        <div className="space-y-1">
-          <h1 className="text-3xl font-bold">Discussions</h1>
-          <p className="text-muted-foreground">This area remained a placeholder in the previous app.</p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/routes/@{$org}/$project/feedback/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/$slug/index.tsx
@@ -10,6 +10,7 @@ import {
   FolderInput,
   Info,
   Link as LinkIcon,
+  MessageSquare,
   Plus,
   Tag,
   UserMinus,
@@ -329,38 +330,45 @@ function FeedbackDetailRoute() {
   )
 
   return (
-    <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-      <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
-        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
-          <div>
-            <div className="flex items-center gap-3">
-              <UpvoteButton
-                feedbackId={feedback.id}
-                initialCount={feedback.upvotes}
-                initialHasUpvoted={feedbackData.hasUpvoted}
-                isAuthenticated={isAuthenticated}
-              />
-              <div className="flex-1">
-                <div className="text-sm font-medium">
-                  {feedback.upvotes} upvote{feedback.upvotes !== 1 ? "s" : ""}
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {feedbackData.hasUpvoted
-                    ? "You've upvoted this"
-                    : "Show your support"}
-                </div>
-              </div>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button className="size-8" size="icon" variant="ghost">
-                    <Bell className="size-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Subscribe to updates</TooltipContent>
-              </Tooltip>
+    <div className="flex flex-1 flex-col">
+      <div className="border-b">
+        <div className="container flex items-start gap-4 pt-10 pb-6">
+          <div className="mt-1">
+            <StatusIcon colored size="28" status={feedback.status} />
+          </div>
+          <div className="flex flex-1 flex-col gap-2">
+            <h1 className="text-3xl">{feedback.title}</h1>
+            <div className="text-sm text-muted-foreground">
+              <span suppressHydrationWarning>
+                {feedback.status === "open" ? "Opened" : "Updated"}{" "}
+                {formatTimestamp(getTimestamp(feedback.createdAt))} ·{" "}
+                {feedback.upvotes} upvote
+                {feedback.upvotes !== 1 ? "s" : ""}
+              </span>
             </div>
           </div>
-
+          <div className="flex shrink-0 items-center gap-1">
+            <UpvoteButton
+              feedbackId={feedback.id}
+              initialCount={feedback.upvotes}
+              initialHasUpvoted={feedbackData.hasUpvoted}
+              isAuthenticated={isAuthenticated}
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button className="size-8" size="icon" variant="ghost">
+                  <Bell className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Subscribe to updates</TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+      <div className="container flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+      <div className="order-last py-8 md:col-span-4 md:border-l md:border-border/75">
+        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
           <SidebarSection
             icon={<Info className="size-3.5" />}
             onOpenChange={(open) => setSidebarSection("details", open)}
@@ -593,23 +601,12 @@ function FeedbackDetailRoute() {
       </div>
 
       <div className="flex flex-col gap-4 py-8 md:col-span-8">
-        <div className="mb-6 flex items-start gap-4 border-b pt-6 pb-6 md:-mr-8.25">
-          <div className="mt-1">
-            <StatusIcon colored size="28" status={feedback.status} />
-          </div>
-          <div className="flex flex-1 flex-col gap-2">
-            <h1 className="text-3xl">{feedback.title}</h1>
-            <div className="text-sm text-muted-foreground">
-              <span suppressHydrationWarning>
-                {feedback.status === "open" ? "Opened" : "Updated"}{" "}
-                {formatTimestamp(getTimestamp(feedback.createdAt))} ·{" "}
-                {feedback.upvotes} upvote
-                {feedback.upvotes !== 1 ? "s" : ""}
-              </span>
-            </div>
-          </div>
+        <div className="flex w-full items-center border-b pb-2">
+          <h2 className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            <MessageSquare className="size-3.5" />
+            Discussion
+          </h2>
         </div>
-
         <CommentEditorProvider>
           {firstComment || timelineItems.length > 0 ? (
             <ul
@@ -745,8 +742,11 @@ function FeedbackDetailRoute() {
           />
         </CommentEditorProvider>
       </div>
+      </div>
+      </div>
     </div>
   )
+
 }
 
 function CommentBadge({

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -11,7 +11,6 @@ import { z } from "zod"
 
 import { RoutePending } from "@/components/route-pending"
 import { Button } from "@/components/ui/button"
-import ArchivePencil from "@/icons/archive-pencil"
 import CirclePlusOutline from "@/icons/circle-plus-outline"
 import Missing from "@/icons/missing"
 import { useCRPC } from "@/lib/convex/crpc"
@@ -243,20 +242,22 @@ function FeedbackListRoute() {
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-        <div className="order-last py-6 md:col-span-3 md:border-l md:border-border/75">
+        <div className="order-last py-8 md:order-first md:col-span-3 md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="border-b pb-6 md:pl-6">
-              <Button asChild className="w-full" size="lg">
+            <div className="border-b pb-6 md:pr-6">
+              <Button asChild className="w-full">
                 <Link
                   params={{ org: orgSlug, project: projectSlug }}
                   to="/@{$org}/$project/feedback/new"
                 >
-                  <CirclePlusOutline size="16px" /> Add feedback
+                  <CirclePlusOutline size="16px" />
+                  Add feedback
+                  <kbd className="ml-1 rounded border border-current px-1.5 py-px text-xs opacity-50 font-sans">⌘O</kbd>
                 </Link>
               </Button>
             </div>
             <div className="mt-4">
-              <div className="border-b pb-6 md:pl-6">
+              <div className="border-b pb-6 md:pr-6">
                 <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                   Boards
                 </h2>
@@ -265,7 +266,7 @@ function FeedbackListRoute() {
                 </div>
               </div>
               {projectData.permissions.canEdit ? (
-                <div className="mt-6 pb-6 md:pl-6">
+                <div className="mt-6 pb-6 md:pr-6">
                   <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                     Options
                   </h2>
@@ -278,15 +279,6 @@ function FeedbackListRoute() {
           </div>
         </div>
         <div className="flex flex-col gap-4 py-8 md:col-span-9">
-          <div className="flex items-start gap-3 border-b pt-6 pb-6 md:-mr-8.25">
-            <ArchivePencil className="mt-1 text-muted-foreground" size="28px" />
-            <div className="flex flex-col gap-1">
-              <h1 className="text-3xl font-bold">Feedback</h1>
-              <p className="text-muted-foreground">
-                Share your ideas and help us improve.
-              </p>
-            </div>
-          </div>
           <FeedbackToolbar />
           <div
             aria-busy={refreshingFeedback || loadingMoreFeedback}

--- a/src/routes/@{$org}/$project/files/index.tsx
+++ b/src/routes/@{$org}/$project/files/index.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import Folder from '@/icons/folder';
-
 export const Route = createFileRoute('/@{$org}/$project/files/')({
   component: PlaceholderPage,
 });
@@ -9,13 +7,6 @@ export const Route = createFileRoute('/@{$org}/$project/files/')({
 function PlaceholderPage() {
   return (
     <div className="container py-10">
-      <div className="flex items-start gap-3 border-b pb-6">
-        <Folder className="mt-1 text-muted-foreground" size="28px" />
-        <div className="space-y-1">
-          <h1 className="text-3xl font-bold">Files</h1>
-          <p className="text-muted-foreground">This area remained a placeholder in the previous app.</p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/routes/@{$org}/$project/roadmap/index.tsx
+++ b/src/routes/@{$org}/$project/roadmap/index.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
 
-import Roadmap from '@/icons/roadmap';
-
 export const Route = createFileRoute('/@{$org}/$project/roadmap/')({
   component: PlaceholderPage,
 });
@@ -9,13 +7,6 @@ export const Route = createFileRoute('/@{$org}/$project/roadmap/')({
 function PlaceholderPage() {
   return (
     <div className="container py-10">
-      <div className="flex items-start gap-3 border-b pb-6">
-        <Roadmap className="mt-1 text-muted-foreground" size="28px" />
-        <div className="space-y-1">
-          <h1 className="text-3xl font-bold">Roadmap</h1>
-          <p className="text-muted-foreground">This area remained a placeholder in the previous app.</p>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/routes/@{$org}/$project/updates/$slug/index.tsx
+++ b/src/routes/@{$org}/$project/updates/$slug/index.tsx
@@ -224,12 +224,65 @@ function UpdateDetailRoute() {
   }
 
   return (
-    <div className="container flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-      <div className="order-last py-6 md:col-span-4 md:border-l md:border-border/75">
-        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
-          <style>{heartPopKeyframes}</style>
-
-          <div className="flex items-center justify-between">
+    <div className="flex flex-1 flex-col">
+      <div className="border-b">
+        <div className="container flex items-start gap-4 pt-10 pb-6">
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="flex items-center gap-2">
+              {update.status === "draft" ? (
+                <Badge
+                  className="text-yellow-600 dark:text-yellow-400"
+                  variant="outline"
+                >
+                  Draft
+                </Badge>
+              ) : null}
+              {update.category ? (
+                <CategoryBadge category={update.category} />
+              ) : null}
+            </div>
+            <h1 className="text-3xl font-bold">{update.title}</h1>
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              {updateData.author ? (
+                <Link
+                  className="flex items-center gap-2 hover:underline"
+                  params={{ username: updateData.author.username }}
+                  to="/u/$username"
+                >
+                  {updateData.author.imageUrl ? (
+                    <img
+                      alt={updateData.author.username}
+                      className="h-5 w-5 rounded-full"
+                      src={updateData.author.imageUrl}
+                    />
+                  ) : (
+                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                      {updateData.author.name?.charAt(0) ?? "?"}
+                    </div>
+                  )}
+                  <span>@{updateData.author.username}</span>
+                </Link>
+              ) : null}
+              {update.publishedAt ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="flex cursor-pointer items-center gap-1">
+                      <Calendar className="h-4 w-4" />
+                      <span suppressHydrationWarning>
+                        {formatRelativeDay(Number(update.publishedAt))}
+                      </span>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <span suppressHydrationWarning>
+                      {formatFullDate(Number(update.publishedAt))}
+                    </span>
+                  </TooltipContent>
+                </Tooltip>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
             <Button
               className={cn(
                 "group gap-2",
@@ -253,52 +306,56 @@ function UpdateDetailRoute() {
                 {likeCount} {likeCount === 1 ? "like" : "likes"}
               </span>
             </Button>
-
-            <div className="flex items-center">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button onClick={handleCopyLink} size="icon" variant="ghost">
-                    {copied ? (
-                      <Check className="size-4" />
-                    ) : (
-                      <Link2 className="size-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {copied ? "Copied!" : "Copy link"}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={handleShareTwitter}
-                    size="icon"
-                    variant="ghost"
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button onClick={handleCopyLink} size="icon" variant="ghost">
+                  {copied ? (
+                    <Check className="size-4" />
+                  ) : (
+                    <Link2 className="size-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {copied ? "Copied!" : "Copy link"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  onClick={handleShareTwitter}
+                  size="icon"
+                  variant="ghost"
+                >
+                  <svg
+                    className="size-4"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      className="size-4"
-                      fill="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                    </svg>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Share on X</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button asChild size="icon" variant="ghost">
-                    <a href={rssUrl}>
-                      <Rss className="size-4" />
-                    </a>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>RSS Feed</TooltipContent>
-              </Tooltip>
-            </div>
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                  </svg>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Share on X</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button asChild size="icon" variant="ghost">
+                  <a href={rssUrl}>
+                    <Rss className="size-4" />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>RSS Feed</TooltipContent>
+            </Tooltip>
           </div>
+        </div>
+      </div>
+      <div className="container flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
+      <div className="order-last py-8 md:col-span-4 md:border-l md:border-border/75">
+        <div className="sticky top-4 flex flex-col gap-6 md:pl-8">
+          <style>{heartPopKeyframes}</style>
 
           <SidebarSection
             icon={<Info className="size-3.5" />}
@@ -387,62 +444,6 @@ function UpdateDetailRoute() {
       </div>
 
       <div className="flex flex-col gap-4 py-8 md:col-span-8">
-        <div className="flex flex-col gap-2 border-b pt-6 pb-6">
-          <div className="flex items-center gap-2">
-            {update.status === "draft" ? (
-              <Badge
-                className="text-yellow-600 dark:text-yellow-400"
-                variant="outline"
-              >
-                Draft
-              </Badge>
-            ) : null}
-            {update.category ? (
-              <CategoryBadge category={update.category} />
-            ) : null}
-          </div>
-          <h1 className="text-3xl font-bold">{update.title}</h1>
-          <div className="flex items-center gap-3 text-sm text-muted-foreground">
-            {updateData.author ? (
-              <Link
-                className="flex items-center gap-2 hover:underline"
-                params={{ username: updateData.author.username }}
-                to="/u/$username"
-              >
-                {updateData.author.imageUrl ? (
-                  <img
-                    alt={updateData.author.username}
-                    className="h-5 w-5 rounded-full"
-                    src={updateData.author.imageUrl}
-                  />
-                ) : (
-                  <div className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
-                    {updateData.author.name?.charAt(0) ?? "?"}
-                  </div>
-                )}
-                <span>@{updateData.author.username}</span>
-              </Link>
-            ) : null}
-            {update.publishedAt ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="flex cursor-pointer items-center gap-1">
-                    <Calendar className="h-4 w-4" />
-                    <span suppressHydrationWarning>
-                      {formatRelativeDay(Number(update.publishedAt))}
-                    </span>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <span suppressHydrationWarning>
-                    {formatFullDate(Number(update.publishedAt))}
-                  </span>
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-          </div>
-        </div>
-
         {updateData.coverImageUrl ? (
           <img
             alt={update.title}
@@ -457,11 +458,12 @@ function UpdateDetailRoute() {
 
         <div className="mt-8 border-t pt-8">
           <CommentEditorProvider>
-            <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold">
-              <MessageSquare className="size-5" />
-              {updateData.commentCount}{" "}
-              {updateData.commentCount === 1 ? "Comment" : "Comments"}
-            </h3>
+            <div className="mb-4 flex w-full items-center border-b pb-2">
+              <h2 className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                <MessageSquare className="size-3.5" />
+                Discussion
+              </h2>
+            </div>
             <CommentList
               comments={comments as ThreadComment[]}
               currentProfileId={currentProfile?.id}
@@ -503,6 +505,8 @@ function UpdateDetailRoute() {
             />
           </CommentEditorProvider>
         </div>
+      </div>
+      </div>
       </div>
     </div>
   )

--- a/src/routes/@{$org}/$project/updates/index.tsx
+++ b/src/routes/@{$org}/$project/updates/index.tsx
@@ -6,7 +6,6 @@ import { z } from "zod"
 
 import { RoutePending } from "@/components/route-pending"
 import { Button } from "@/components/ui/button"
-import CalendarDays from "@/icons/calendar-days"
 import CirclePlusOutline from "@/icons/circle-plus-outline"
 import Missing from "@/icons/missing"
 import { Settings2 } from "lucide-react"
@@ -97,9 +96,9 @@ function UpdatesListRoute() {
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-        <div className="order-last py-6 md:col-span-3 md:border-l md:border-border/75">
+        <div className="order-last py-6 md:order-first md:col-span-3 md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="pb-6 md:pl-6">
+            <div className="pb-6 md:pr-6">
               <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                 Categories
               </h2>
@@ -108,7 +107,7 @@ function UpdatesListRoute() {
               </div>
             </div>
             {canEdit ? (
-              <div className="border-t pt-6 md:pl-6">
+              <div className="border-t pt-6 md:pr-6">
                 <h2 className="mx-2 text-sm font-bold text-muted-foreground">
                   Actions
                 </h2>
@@ -141,16 +140,6 @@ function UpdatesListRoute() {
           aria-busy={updatesQuery.isFetching}
           aria-live="polite"
         >
-          <div className="flex items-start gap-3 border-b pt-6 pb-6 md:-mr-8.25">
-            <CalendarDays className="mt-1 text-muted-foreground" size="28px" />
-            <div className="flex flex-col gap-1">
-              <h1 className="text-3xl font-bold">Updates</h1>
-              <p className="text-muted-foreground">
-                The latest news and announcements.
-              </p>
-            </div>
-          </div>
-
           {updates.length === 0 ? (
             <Notice icon={<Missing aria-hidden="true" size="32px" />}>
               No updates yet.


### PR DESCRIPTION
## What changed

- Removed redundant heading blocks from placeholder project routes for chat, discussions, files, and roadmap.
- Moved feedback and updates detail-page metadata into a shared top header area and labeled the comment section as "Discussion".
- Repositioned the feedback and updates list-page sidebars to the left rail and tightened the related action/filter layout.

## Why this changed

These pages were repeating page titles and introductory copy inside the main content area even though the surrounding project shell already provides context. Consolidating the detail-page headers and removing duplicate section headings makes the layouts cleaner and gives the discussion content more focus.

## Follow-up and test notes

- `git diff --cached --check` passed.
- I could not run `eslint` in this workspace because the local `eslint` binary is not available from `pnpm exec eslint`.
