### PR TITLE
Fix cascading deletes for bulk update removal

### DIFF
--- a/convex/functions/schema.ts
+++ b/convex/functions/schema.ts
@@ -716,7 +716,7 @@ export const updateCommentTable = convexTable(
     updatedTime: integer(),
     updateId: id("update")
       .notNull()
-      .references(() => updateTable.id),
+      .references(() => updateTable.id, { onDelete: "cascade" }),
     authorProfileId: id("profile")
       .notNull()
       .references(() => profileTable.id),
@@ -735,7 +735,7 @@ export const updateEmoteTable = convexTable(
     updatedTime: integer(),
     updateId: id("update")
       .notNull()
-      .references(() => updateTable.id),
+      .references(() => updateTable.id, { onDelete: "cascade" }),
     authorProfileId: id("profile")
       .notNull()
       .references(() => profileTable.id),
@@ -757,10 +757,10 @@ export const updateCommentEmoteTable = convexTable(
     updatedTime: integer(),
     updateId: id("update")
       .notNull()
-      .references(() => updateTable.id),
+      .references(() => updateTable.id, { onDelete: "cascade" }),
     updateCommentId: id("updateComment")
       .notNull()
-      .references(() => updateCommentTable.id),
+      .references(() => updateCommentTable.id, { onDelete: "cascade" }),
     authorProfileId: id("profile")
       .notNull()
       .references(() => profileTable.id),


### PR DESCRIPTION
## What changed
- add `onDelete: "cascade"` to `updateComment.updateId`, `updateEmote.updateId`, `updateCommentEmote.updateId`, and `updateCommentEmote.updateCommentId`
- let deleting an update or comment automatically remove dependent comments and emotes

## Why
Bulk update deletion removes `update` rows directly. Without cascading foreign keys, existing comments or emotes can block the delete and leave bulk removal failing for updates with child records.

## Test notes
- ran `pnpm run typecheck:convex`
- did not run broader app or integration tests