### PR TITLE
Fix missing main nav border on org pages

### DIFF
--- a/src/routes/@{$org}/-components/main-nav.tsx
+++ b/src/routes/@{$org}/-components/main-nav.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
 
 const notifications = [
   {
@@ -70,7 +71,7 @@ export const MainNav = ({
 
   return (
     <>
-      <nav className="bg-muted dark:bg-black">
+      <nav className={cn("bg-muted dark:bg-black", !projectSlug && "border-b")}>
         <div className="container">
           {/* Top row */}
           <div className="flex items-center justify-between py-3">


### PR DESCRIPTION
## What changed

- Added `cn` to `main-nav.tsx` and conditionally apply `border-b` to the top nav when there is no `projectSlug`.

## Why

- Org-level pages without a selected project were missing a bottom border on the main navigation, which made the header look visually incomplete compared with project-scoped pages.

## Follow-up / test notes

- No automated checks were run for this small UI-only change.
