### PR TITLE
Support right-click behavior on feedback cards

### DIFF
--- a/src/components/clickable-container.tsx
+++ b/src/components/clickable-container.tsx
@@ -7,6 +7,7 @@ interface ClickableContainerProps {
   children: React.ReactNode
   className?: string
   href?: string
+  keyboardInteractive?: boolean
   "aria-label"?: string
   "aria-labelledby"?: string
   "aria-describedby"?: string
@@ -33,6 +34,7 @@ export const ClickableContainer = forwardRef<
       children,
       className = "",
       href,
+      keyboardInteractive = true,
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       "aria-describedby": ariaDescribedBy,
@@ -143,15 +145,15 @@ export const ClickableContainer = forwardRef<
     return (
       <div
         ref={ref}
-        role="button"
-        tabIndex={disabled ? -1 : 0}
+        role={keyboardInteractive ? "button" : undefined}
+        tabIndex={keyboardInteractive ? (disabled ? -1 : 0) : undefined}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
-        aria-disabled={disabled}
+        aria-disabled={keyboardInteractive ? disabled : undefined}
         onClick={handleClick}
         onContextMenuCapture={handleContextLinkContextMenu}
-        onKeyDown={handleKeyDown}
+        onKeyDown={keyboardInteractive ? handleKeyDown : undefined}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/src/components/clickable-container.tsx
+++ b/src/components/clickable-container.tsx
@@ -1,102 +1,178 @@
 // components/ClickableCard.tsx
-import { forwardRef, useRef, useState } from 'react';
+import { forwardRef, useEffect, useRef, useState } from "react"
+import { flushSync } from "react-dom"
 
 interface ClickableContainerProps {
-	onClick: () => void;
-	children: React.ReactNode;
-	className?: string;
-	'aria-label'?: string;
-	'aria-labelledby'?: string;
-	'aria-describedby'?: string;
-	disabled?: boolean;
+  onClick: () => void
+  children: React.ReactNode
+  className?: string
+  href?: string
+  "aria-label"?: string
+  "aria-labelledby"?: string
+  "aria-describedby"?: string
+  disabled?: boolean
 }
 
-export const ClickableContainer = forwardRef<HTMLDivElement, ClickableContainerProps>(
-	(
-		{
-			onClick,
-			children,
-			className = '',
-			'aria-label': ariaLabel,
-			'aria-labelledby': ariaLabelledBy,
-			'aria-describedby': ariaDescribedBy,
-			disabled = false,
-			...props
-		},
-		ref
-	) => {
-		const [hasActiveSelection, setHasActiveSelection] = useState(false);
-		const mouseStartPos = useRef<{ x: number; y: number } | null>(null);
+const interactiveSelector = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  '[role="button"]',
+  '[role="link"]',
+].join(",")
 
-		const handleMouseDown = (e: React.MouseEvent) => {
-			mouseStartPos.current = { x: e.clientX, y: e.clientY };
-			setHasActiveSelection(false);
-		};
+export const ClickableContainer = forwardRef<
+  HTMLDivElement,
+  ClickableContainerProps
+>(
+  (
+    {
+      onClick,
+      children,
+      className = "",
+      href,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
+      disabled = false,
+      ...props
+    },
+    ref
+  ) => {
+    const [hasActiveSelection, setHasActiveSelection] = useState(false)
+    const [showContextLink, setShowContextLink] = useState(false)
+    const mouseStartPos = useRef<{ x: number; y: number } | null>(null)
+    const contextLinkTimeout = useRef<ReturnType<typeof setTimeout> | null>(
+      null
+    )
 
-		const handleMouseMove = (e: React.MouseEvent) => {
-			if (!mouseStartPos.current) return;
+    useEffect(() => {
+      return () => {
+        if (contextLinkTimeout.current) {
+          clearTimeout(contextLinkTimeout.current)
+        }
+      }
+    }, [])
 
-			const moved =
-				Math.abs(e.clientX - mouseStartPos.current.x) > 3 ||
-				Math.abs(e.clientY - mouseStartPos.current.y) > 3;
+    const hideContextLink = () => {
+      if (contextLinkTimeout.current) {
+        clearTimeout(contextLinkTimeout.current)
+        contextLinkTimeout.current = null
+      }
 
-			if (moved) {
-				setHasActiveSelection(true);
-			}
-		};
+      setShowContextLink(false)
+    }
 
-		const handleMouseUp = () => {
-			setTimeout(() => {
-				const selection = window.getSelection();
-				const hasSelection = selection && selection.toString().length > 0 ? true : false;
-				setHasActiveSelection(hasSelection);
-			}, 10);
-		};
+    const handlePointerDownCapture = (e: React.PointerEvent) => {
+      if (!href || disabled) return
 
-		const handleClick = (e: React.MouseEvent) => {
-			if (disabled || hasActiveSelection) {
-				return;
-			}
+      const isContextMenuPointerDown =
+        e.button === 2 || (e.button === 0 && e.ctrlKey)
+      if (!isContextMenuPointerDown) return
 
-			// Don't navigate if clicking on interactive elements
-			const target = e.target as HTMLElement;
-			if (target.tagName === 'A' || target.tagName === 'BUTTON' || target.tagName === 'INPUT') {
-				return;
-			}
+      flushSync(() => {
+        setShowContextLink(true)
+      })
 
-			onClick();
-		};
+      if (contextLinkTimeout.current) {
+        clearTimeout(contextLinkTimeout.current)
+      }
 
-		const handleKeyDown = (e: React.KeyboardEvent) => {
-			if (disabled) return;
+      contextLinkTimeout.current = setTimeout(() => {
+        setShowContextLink(false)
+        contextLinkTimeout.current = null
+      }, 2000)
+    }
 
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				onClick();
-			}
-		};
+    const handleMouseDown = (e: React.MouseEvent) => {
+      mouseStartPos.current = { x: e.clientX, y: e.clientY }
+      setHasActiveSelection(false)
+    }
 
-		return (
-			<div
-				ref={ref}
-				role='button'
-				tabIndex={disabled ? -1 : 0}
-				aria-label={ariaLabel}
-				aria-labelledby={ariaLabelledBy}
-				aria-describedby={ariaDescribedBy}
-				aria-disabled={disabled}
-				onClick={handleClick}
-				onKeyDown={handleKeyDown}
-				onMouseDown={handleMouseDown}
-				onMouseMove={handleMouseMove}
-				onMouseUp={handleMouseUp}
-				className={` ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'} focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${className} `}
-				{...props}
-			>
-				{children}
-			</div>
-		);
-	}
-);
+    const handleMouseMove = (e: React.MouseEvent) => {
+      if (!mouseStartPos.current) return
 
-ClickableContainer.displayName = 'ClickableContainer';
+      const moved =
+        Math.abs(e.clientX - mouseStartPos.current.x) > 3 ||
+        Math.abs(e.clientY - mouseStartPos.current.y) > 3
+
+      if (moved) {
+        setHasActiveSelection(true)
+      }
+    }
+
+    const handleMouseUp = () => {
+      setTimeout(() => {
+        const selection = window.getSelection()
+        const hasSelection =
+          selection && selection.toString().length > 0 ? true : false
+        setHasActiveSelection(hasSelection)
+      }, 10)
+    }
+
+    const handleClick = (e: React.MouseEvent) => {
+      if (disabled || hasActiveSelection) {
+        return
+      }
+
+      // Don't navigate if clicking on interactive elements
+      const target = e.target as HTMLElement
+      const interactiveElement = target.closest(interactiveSelector)
+      if (interactiveElement && interactiveElement !== e.currentTarget) {
+        return
+      }
+
+      onClick()
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (disabled) return
+
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        onClick()
+      }
+    }
+
+    const handleContextLinkContextMenu = () => {
+      setTimeout(hideContextLink, 0)
+    }
+
+    return (
+      <div
+        ref={ref}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-disabled={disabled}
+        onClick={handleClick}
+        onContextMenuCapture={handleContextLinkContextMenu}
+        onKeyDown={handleKeyDown}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onPointerDownCapture={handlePointerDownCapture}
+        className={`relative ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"} focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${className} `}
+        {...props}
+      >
+        {children}
+        {href && showContextLink ? (
+          <a
+            aria-hidden="true"
+            className="absolute inset-0 z-10 cursor-pointer"
+            draggable={false}
+            href={href}
+            onContextMenu={handleContextLinkContextMenu}
+            tabIndex={-1}
+          />
+        ) : null}
+      </div>
+    )
+  }
+)
+
+ClickableContainer.displayName = "ClickableContainer"

--- a/src/routes/@{$org}/$project/feedback/-components/feedback-card.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/feedback-card.tsx
@@ -4,16 +4,41 @@ import { stripHtml, truncateToNearestSpace } from "@/lib/utils/truncate"
 
 import { UpvoteButton } from "./upvote-button"
 
+function isPlainLeftClick(event: React.MouseEvent<HTMLAnchorElement>) {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  )
+}
+
 export function FeedbackCard({
+  href,
   onNavigationClick,
   feedback,
   isAuthenticated,
 }: {
+  href: string
   onNavigationClick: () => void
   feedback: any
   isAuthenticated: boolean
 }) {
   const { title, firstComment, upvotes, board, status, hasUpvoted } = feedback
+
+  const handleTitleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!isPlainLeftClick(event)) return
+
+    const selection = window.getSelection()
+    if (selection?.toString()) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    onNavigationClick?.()
+  }
 
   return (
     <li className="flex rounded-lg border bg-card">
@@ -27,6 +52,7 @@ export function FeedbackCard({
       </div>
       <ClickableContainer
         className="group flex w-full flex-col rounded-r-lg p-5 transition-colors duration-100 ease-in-out hocus:bg-accent/50 hocus:outline-primary"
+        href={href}
         onClick={() => onNavigationClick?.()}
       >
         <div className="flex items-start gap-4">
@@ -34,9 +60,14 @@ export function FeedbackCard({
             <StatusIcon colored size="30px" status={status} />
           </div>
           <div>
-            <span className="text-xl font-medium underline-offset-2 group-hover:underline">
+            <a
+              className="text-xl font-medium underline-offset-2 group-hover:underline"
+              draggable={false}
+              href={href}
+              onClick={handleTitleClick}
+            >
               {title}
-            </span>
+            </a>
             <div className="mt-2 h-full max-h-62.5 space-y-4 overflow-hidden text-sm text-ellipsis text-muted-foreground">
               {truncateToNearestSpace(
                 stripHtml(firstComment?.content ?? ""),

--- a/src/routes/@{$org}/$project/feedback/-components/feedback-card.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/feedback-card.tsx
@@ -53,6 +53,7 @@ export function FeedbackCard({
       <ClickableContainer
         className="group flex w-full flex-col rounded-r-lg p-5 transition-colors duration-100 ease-in-out hocus:bg-accent/50 hocus:outline-primary"
         href={href}
+        keyboardInteractive={false}
         onClick={() => onNavigationClick?.()}
       >
         <div className="flex items-start gap-4">

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -252,7 +252,9 @@ function FeedbackListRoute() {
                 >
                   <CirclePlusOutline size="16px" />
                   Add feedback
-                  <kbd className="ml-1 rounded border border-current px-1.5 py-px text-xs opacity-50 font-sans">⌘O</kbd>
+                  <kbd className="ml-1 rounded border border-current px-1.5 py-px font-sans text-xs opacity-50">
+                    ⌘O
+                  </kbd>
                 </Link>
               </Button>
             </div>
@@ -291,23 +293,34 @@ function FeedbackListRoute() {
             ) : null}
             {feedback.length > 0 ? (
               <ul className="flex flex-col gap-4">
-                {feedback.map((item) => (
-                  <FeedbackCard
-                    key={item.id}
-                    feedback={item}
-                    isAuthenticated={!!profileQuery.data}
-                    onNavigationClick={() =>
-                      router.navigate({
-                        params: {
-                          org: orgSlug,
-                          project: projectSlug,
-                          slug: item.slug,
-                        },
-                        to: "/@{$org}/$project/feedback/$slug",
-                      })
-                    }
-                  />
-                ))}
+                {feedback.map((item) => {
+                  const feedbackLinkOptions = {
+                    params: {
+                      org: orgSlug,
+                      project: projectSlug,
+                      slug: item.slug,
+                    },
+                    to: "/@{$org}/$project/feedback/$slug",
+                  } as const
+                  const feedbackLocation =
+                    router.buildLocation(feedbackLinkOptions)
+
+                  return (
+                    <FeedbackCard
+                      key={item.id}
+                      feedback={item}
+                      href={
+                        router.history.createHref(
+                          feedbackLocation.publicHref
+                        ) || "/"
+                      }
+                      isAuthenticated={!!profileQuery.data}
+                      onNavigationClick={() =>
+                        router.navigate(feedbackLinkOptions)
+                      }
+                    />
+                  )
+                })}
               </ul>
             ) : null}
           </div>


### PR DESCRIPTION
## What changed
- taught `ClickableContainer` to expose a temporary overlay link during right-click / ctrl-click so the browser context menu can treat feedback cards like real links
- passed concrete feedback detail `href` values into each card and rendered the card title as an actual anchor
- preserved client-side navigation for normal left-clicks while avoiding navigation when text is selected or when nested interactive elements are clicked

## Why this changed
Feedback cards were visually clickable, but they did not behave like links in the browser. That prevented expected actions like right-clicking to open a card in a new tab or copying the destination from the context menu.

## Follow-up / test notes
- Verified with `pnpm typecheck`
- No dedicated automated UI test was added for the new context-menu behavior
