### PR TITLE
Fix shared nav auth and placeholder states

### DIFF
--- a/src/components/site-nav/main-nav.tsx
+++ b/src/components/site-nav/main-nav.tsx
@@ -214,43 +214,52 @@ export const MainNav = ({
                   <span className="sr-only">Search</span>
                 </NavButton>
 
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <NavButton size="icon" className="relative">
-                      <Bell className="h-4 w-4" />
-                      <Badge
-                        variant="destructive"
-                        className="absolute -top-1 -right-1 h-4 w-4 p-0 text-xs"
+                {user ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <NavButton
+                        aria-label={`Open notifications (${notifications.length} unread)`}
+                        size="icon"
+                        className="relative"
                       >
-                        {notifications.length}
-                      </Badge>
-                    </NavButton>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="z-20 w-80">
-                    <div className="px-3 py-2 text-sm font-semibold">
-                      Notifications
-                    </div>
-                    <DropdownMenuSeparator />
-                    {notifications.map((notification) => (
-                      <DropdownMenuItem
-                        key={notification.id}
-                        className="flex flex-col items-start p-3"
-                      >
-                        <div className="font-medium">{notification.title}</div>
-                        <div className="text-sm text-muted-foreground">
-                          {notification.description}
-                        </div>
-                        <div className="mt-1 text-xs text-muted-foreground">
-                          {notification.time}
-                        </div>
+                        <Bell className="h-4 w-4" />
+                        <Badge
+                          aria-hidden="true"
+                          variant="destructive"
+                          className="absolute -top-1 -right-1 h-4 w-4 p-0 text-xs"
+                        >
+                          {notifications.length}
+                        </Badge>
+                      </NavButton>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-20 w-80">
+                      <div className="px-3 py-2 text-sm font-semibold">
+                        Notifications
+                      </div>
+                      <DropdownMenuSeparator />
+                      {notifications.map((notification) => (
+                        <DropdownMenuItem
+                          key={notification.id}
+                          className="flex flex-col items-start p-3"
+                        >
+                          <div className="font-medium">
+                            {notification.title}
+                          </div>
+                          <div className="text-sm text-muted-foreground">
+                            {notification.description}
+                          </div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {notification.time}
+                          </div>
+                        </DropdownMenuItem>
+                      ))}
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-center text-sm text-muted-foreground">
+                        View all notifications
                       </DropdownMenuItem>
-                    ))}
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem className="text-center text-sm text-muted-foreground">
-                      View all notifications
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
 
                 {user ? (
                   <UserDropdown orgSlug={orgSlug} user={user} />

--- a/src/components/site-nav/user-dropdown.tsx
+++ b/src/components/site-nav/user-dropdown.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import {
   Building2,
@@ -19,7 +20,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { authClient } from "@/lib/auth/auth-client"
+import { useSignOutMutationOptions } from "@/lib/auth/auth-client"
 
 export function UserDropdown({
   orgSlug,
@@ -29,6 +30,7 @@ export function UserDropdown({
   user: NonNullable<API["profile"]["findMyProfile"]>
 }) {
   const navigate = useNavigate()
+  const signOut = useMutation(useSignOutMutationOptions())
 
   return (
     <DropdownMenu>
@@ -60,8 +62,12 @@ export function UserDropdown({
         >
           Your profile
         </UserDropdownItem>
-        <UserDropdownItem icon={Building2}>Your organizations</UserDropdownItem>
-        <UserDropdownItem icon={FolderKanban}>Your projects</UserDropdownItem>
+        <UserDropdownItem disabled icon={Building2}>
+          Your organizations
+        </UserDropdownItem>
+        <UserDropdownItem disabled icon={FolderKanban}>
+          Your projects
+        </UserDropdownItem>
         <DropdownMenuSeparator />
         {!!orgSlug && (
           <UserDropdownItem
@@ -88,15 +94,19 @@ export function UserDropdown({
         </UserDropdownItem>
         <DropdownMenuSeparator />
         <UserDropdownItem
+          disabled={signOut.isPending}
           icon={LogOut}
           onClick={() => {
-            authClient.signOut()
-            navigate({
-              to: "/auth",
+            signOut.mutate(undefined, {
+              onSuccess: () => {
+                navigate({
+                  to: "/auth",
+                })
+              },
             })
           }}
         >
-          Sign out
+          {signOut.isPending ? "Signing out..." : "Sign out"}
         </UserDropdownItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -105,15 +115,17 @@ export function UserDropdown({
 
 function UserDropdownItem({
   children,
+  disabled,
   icon: Icon,
   onClick,
 }: {
   children: React.ReactNode
+  disabled?: boolean
   icon: ComponentType<{ className?: string }>
   onClick?: () => void
 }) {
   return (
-    <DropdownMenuItem className="gap-2" onClick={onClick}>
+    <DropdownMenuItem className="gap-2" disabled={disabled} onClick={onClick}>
       <Icon className="size-4 text-muted-foreground/65" />
       <span>{children}</span>
     </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- use the kitcn sign-out mutation wrapper in the shared user dropdown
- hide placeholder notifications unless a user is authenticated
- add an accessible notification button label
- disable unfinished organizations/projects dropdown items

## Verification
- pnpm typecheck
- git diff --check