### PR TITLE
Add feedback keyboard shortcuts and seed import sanitization

### DIFF
--- a/scripts/seed-convex-from-dev.mjs
+++ b/scripts/seed-convex-from-dev.mjs
@@ -289,18 +289,20 @@ function removeJsonlObjectFields(filePath, fields) {
   let changed = 0
   const sanitizedLines = []
 
+  // Each line is a complete JSON object, so parse it rather than rewriting the
+  // text with regexes — that keeps us safe regardless of a field's value type.
   for (const line of lines) {
     if (!line.trim()) continue
-    let sanitizedLine = line
+    const row = JSON.parse(line)
+    let touched = false
     for (const field of fields) {
-      const quotedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-      sanitizedLine = sanitizedLine
-        .replace(new RegExp(`,"${quotedField}":[^,}]*`, "g"), "")
-        .replace(new RegExp(`"${quotedField}":[^,}]*,`, "g"), "")
-        .replace(new RegExp(`"${quotedField}":[^,}]*`, "g"), "")
+      if (field in row) {
+        delete row[field]
+        touched = true
+      }
     }
-    if (sanitizedLine !== line) changed += 1
-    sanitizedLines.push(sanitizedLine)
+    if (touched) changed += 1
+    sanitizedLines.push(JSON.stringify(row))
   }
 
   if (changed > 0) {
@@ -311,6 +313,12 @@ function removeJsonlObjectFields(filePath, fields) {
 }
 
 function sanitizeExportForCurrentSchema(exportPath) {
+  if (!exportPath.endsWith(".zip")) {
+    throw new Error(
+      `[seed] expected a .zip export path, got: ${exportPath}`
+    )
+  }
+
   const tempDir = fs.mkdtempSync(path.join(seedDir, "sanitize-"))
   const sanitizedPath = exportPath.replace(/\.zip$/, "-sanitized.zip")
 
@@ -327,6 +335,8 @@ function sanitizeExportForCurrentSchema(exportPath) {
     console.log(
       `[seed] removed legacy feedback soft-delete fields from ${changedFeedbackRows} exported row(s)`
     )
+    // Start from a clean file so re-runs don't append to a stale archive.
+    fs.rmSync(sanitizedPath, { force: true })
     run("zip", ["-q", "-r", sanitizedPath, "."], { cwd: tempDir })
     return sanitizedPath
   } finally {
@@ -440,6 +450,12 @@ run(
   ],
   { env: targetEnv }
 )
+
+// Drop the temporary sanitized archive (if one was produced) now that the
+// import has consumed it.
+if (importPath !== exportPath) {
+  fs.rmSync(importPath, { force: true })
+}
 
 stopTemporaryLocalBackend()
 

--- a/scripts/seed-convex-from-dev.mjs
+++ b/scripts/seed-convex-from-dev.mjs
@@ -115,10 +115,14 @@ function assertTargetIsSafe() {
   process.exit(1)
 }
 
-function run(command, args, { capture = false, env = process.env } = {}) {
+function run(
+  command,
+  args,
+  { capture = false, cwd = workspaceRoot, env = process.env } = {}
+) {
   console.log(`[seed] ${command} ${args.join(" ")}`)
   const result = spawnSync(command, args, {
-    cwd: workspaceRoot,
+    cwd,
     encoding: "utf8",
     env,
     stdio: capture ? ["ignore", "pipe", "inherit"] : "inherit",
@@ -278,6 +282,58 @@ function timestamp() {
   return new Date().toISOString().replace(/[:.]/g, "-")
 }
 
+function removeJsonlObjectFields(filePath, fields) {
+  if (!fs.existsSync(filePath)) return 0
+
+  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/)
+  let changed = 0
+  const sanitizedLines = []
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+    let sanitizedLine = line
+    for (const field of fields) {
+      const quotedField = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+      sanitizedLine = sanitizedLine
+        .replace(new RegExp(`,"${quotedField}":[^,}]*`, "g"), "")
+        .replace(new RegExp(`"${quotedField}":[^,}]*,`, "g"), "")
+        .replace(new RegExp(`"${quotedField}":[^,}]*`, "g"), "")
+    }
+    if (sanitizedLine !== line) changed += 1
+    sanitizedLines.push(sanitizedLine)
+  }
+
+  if (changed > 0) {
+    fs.writeFileSync(filePath, `${sanitizedLines.join("\n")}\n`)
+  }
+
+  return changed
+}
+
+function sanitizeExportForCurrentSchema(exportPath) {
+  const tempDir = fs.mkdtempSync(path.join(seedDir, "sanitize-"))
+  const sanitizedPath = exportPath.replace(/\.zip$/, "-sanitized.zip")
+
+  try {
+    run("unzip", ["-q", exportPath, "-d", tempDir])
+
+    const changedFeedbackRows = removeJsonlObjectFields(
+      path.join(tempDir, "feedback", "documents.jsonl"),
+      ["deletedTime", "deletionScheduled"]
+    )
+
+    if (changedFeedbackRows === 0) return exportPath
+
+    console.log(
+      `[seed] removed legacy feedback soft-delete fields from ${changedFeedbackRows} exported row(s)`
+    )
+    run("zip", ["-q", "-r", sanitizedPath, "."], { cwd: tempDir })
+    return sanitizedPath
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
 process.on("exit", stopTemporaryLocalBackend)
 process.on("SIGINT", () => {
   stopTemporaryLocalBackend()
@@ -367,6 +423,7 @@ run("pnpm", [
   exportPath,
   ...(options.includeFileStorage ? ["--include-file-storage"] : []),
 ])
+const importPath = sanitizeExportForCurrentSchema(exportPath)
 
 startTemporaryLocalBackend(targetEnv)
 
@@ -376,7 +433,7 @@ run(
     "exec",
     "convex",
     "import",
-    exportPath,
+    importPath,
     "--replace-all",
     "--yes",
     ...targetArgs(),

--- a/src/components/command/command-palette.tsx
+++ b/src/components/command/command-palette.tsx
@@ -49,8 +49,6 @@ export function CommandPalette({
     return grouped
   }, [commands])
   const groupOrder = useMemo(() => {
-    if (!query.trim()) return GROUP_ORDER
-
     const contextualGroups = GROUP_ORDER.filter((group) =>
       commandsByGroup.get(group)?.some((command) => command.contextual)
     )
@@ -59,7 +57,7 @@ export function CommandPalette({
     )
 
     return [...contextualGroups, ...remainingGroups]
-  }, [commandsByGroup, query])
+  }, [commandsByGroup])
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react"
 import type { ConvexQueryClient } from "kitcn/react"
 
 import { CommandProvider } from "@/components/command"
+import { ShortcutsProvider } from "@/components/shortcuts"
 import { AppConvexProvider } from "@/lib/convex/convex-provider"
 
 export function Providers({
@@ -18,7 +19,9 @@ export function Providers({
       convexQueryClient={convexQueryClient}
       initialToken={initialToken}
     >
-      <CommandProvider>{children}</CommandProvider>
+      <CommandProvider>
+        <ShortcutsProvider>{children}</ShortcutsProvider>
+      </CommandProvider>
     </AppConvexProvider>
   )
 }

--- a/src/components/shortcuts/index.ts
+++ b/src/components/shortcuts/index.ts
@@ -1,0 +1,3 @@
+export { ShortcutsProvider } from "./shortcuts-provider"
+export { useRegisterShortcuts, useShortcuts } from "./use-shortcuts"
+export type { Shortcut, ShortcutGroupName } from "./types"

--- a/src/components/shortcuts/keys.ts
+++ b/src/components/shortcuts/keys.ts
@@ -58,3 +58,22 @@ export function isEditableTarget(target: EventTarget | null): boolean {
 export function hasReservedModifier(event: KeyboardEvent): boolean {
   return event.metaKey || event.ctrlKey || event.altKey
 }
+
+// Open dialogs/menus render with one of these markers. We suppress page-level
+// single-key shortcuts while any such overlay is open so a stray keystroke on a
+// non-editable control inside it can't trigger navigation underneath the layer.
+const OPEN_OVERLAY_SELECTOR = [
+  '[data-slot="dialog-content"]',
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '[role="menu"][data-open]',
+  '[data-slot="popover-content"]',
+].join(", ")
+
+/**
+ * True when an overlay (dialog, command palette, popover, open menu) is present
+ * in the DOM. Used to keep single-key shortcuts inert while a layer is open.
+ */
+export function isOverlayOpen(): boolean {
+  return document.querySelector(OPEN_OVERLAY_SELECTOR) !== null
+}

--- a/src/components/shortcuts/keys.ts
+++ b/src/components/shortcuts/keys.ts
@@ -1,0 +1,60 @@
+/**
+ * Normalizes a key for matching: single characters are lowercased so letter
+ * shortcuts are case-insensitive, while named keys (Escape, ArrowDown, …) and
+ * symbols/digits are kept verbatim.
+ */
+export function normalizeKey(key: string): string {
+  return key.length === 1 ? key.toLowerCase() : key
+}
+
+// Widget roles that consume their own keystrokes (typeahead, arrow nav, etc.).
+// While focus is inside one of these we must not hijack single-letter keys.
+const KEY_CONSUMING_ROLES = [
+  "textbox",
+  "searchbox",
+  "combobox",
+  "listbox",
+  "option",
+  "menu",
+  "menubar",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "slider",
+  "spinbutton",
+  "tree",
+  "treeitem",
+  "grid",
+  "gridcell",
+]
+
+const KEY_CONSUMING_SELECTOR = [
+  '[contenteditable="true"]',
+  ...KEY_CONSUMING_ROLES.map((role) => `[role="${role}"]`),
+].join(", ")
+
+/**
+ * True when the event target is a field/widget that handles its own typing or
+ * key navigation, so we never hijack single-letter keystrokes from inputs,
+ * textareas, native selects, the command palette, the markdown editor, or
+ * combobox/listbox/menu-style controls (e.g. our Select while focused/open).
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+
+  const tag = target.tagName
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true
+  if (target.isContentEditable) return true
+  if (target.closest(KEY_CONSUMING_SELECTOR)) return true
+
+  return false
+}
+
+/**
+ * True when a modifier that we want to leave to the browser/OS is held. We
+ * intentionally allow Shift so symbols like "?" still resolve, while bailing on
+ * ⌘/Ctrl/Alt to avoid stepping on system and browser shortcuts.
+ */
+export function hasReservedModifier(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey || event.altKey
+}

--- a/src/components/shortcuts/shortcuts-context.ts
+++ b/src/components/shortcuts/shortcuts-context.ts
@@ -1,0 +1,17 @@
+import { createContext } from "react"
+
+import type { Shortcut } from "./types"
+
+export type ShortcutsContextValue = {
+  close: () => void
+  open: () => void
+  toggle: () => void
+  registerShortcuts: (
+    scopeId: string,
+    shortcuts: Array<Shortcut>
+  ) => () => void
+}
+
+export const ShortcutsContext = createContext<ShortcutsContextValue | null>(
+  null
+)

--- a/src/components/shortcuts/shortcuts-dialog.tsx
+++ b/src/components/shortcuts/shortcuts-dialog.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from "react"
+
+import type { Shortcut, ShortcutGroupName } from "./types"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+const GROUP_ORDER: Array<ShortcutGroupName> = ["Global", "Feedback"]
+
+type ShortcutsDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  shortcuts: Array<Shortcut>
+}
+
+export function ShortcutsDialog({
+  open,
+  onOpenChange,
+  shortcuts,
+}: ShortcutsDialogProps) {
+  const groups = useMemo(() => {
+    const byGroup = new Map<ShortcutGroupName, Array<Shortcut>>()
+
+    for (const shortcut of shortcuts) {
+      if (shortcut.hidden) continue
+      if (shortcut.enabled && !shortcut.enabled()) continue
+
+      const existing = byGroup.get(shortcut.group)
+      if (existing) {
+        existing.push(shortcut)
+      } else {
+        byGroup.set(shortcut.group, [shortcut])
+      }
+    }
+
+    return GROUP_ORDER.flatMap((group) => {
+      const items = byGroup.get(group)
+      return items && items.length > 0 ? [{ group, items }] : []
+    })
+  }, [shortcuts])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="-mx-4 -mt-4 rounded-t-xl border-b bg-muted px-4 pt-4 pb-4">
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Shortcuts available here. Press a single key — no modifiers needed.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-5">
+          {groups.map(({ group, items }) => (
+            <section key={group} className="flex flex-col gap-1">
+              <h3 className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                {group}
+              </h3>
+              <ul className="flex flex-col">
+                {items.map((shortcut) => (
+                  <li
+                    key={shortcut.id}
+                    className="flex items-center justify-between gap-4 py-1.5"
+                  >
+                    <span className="text-sm">{shortcut.description}</span>
+                    <ShortcutKeys shortcut={shortcut} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ShortcutKeys({ shortcut }: { shortcut: Shortcut }) {
+  const tokens = shortcut.label
+    ? [shortcut.label]
+    : shortcut.keys.map((key) => (key === " " ? "Space" : key))
+
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {tokens.map((token, index) => (
+        <kbd
+          key={`${shortcut.id}-${token}-${index}`}
+          className="inline-flex min-w-6 items-center justify-center rounded border bg-muted px-1.5 py-0.5 font-sans text-xs font-medium text-muted-foreground"
+        >
+          {token}
+        </kbd>
+      ))}
+    </span>
+  )
+}

--- a/src/components/shortcuts/shortcuts-provider.tsx
+++ b/src/components/shortcuts/shortcuts-provider.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
-import { hasReservedModifier, isEditableTarget, normalizeKey } from "./keys"
+import {
+  hasReservedModifier,
+  isEditableTarget,
+  isOverlayOpen,
+  normalizeKey,
+} from "./keys"
 import { ShortcutsContext } from "./shortcuts-context"
 import { ShortcutsDialog } from "./shortcuts-dialog"
 import type { ReactNode } from "react"
@@ -98,6 +103,11 @@ export function ShortcutsProvider({ children }: { children: ReactNode }) {
       // While the modal is open only the toggle key is live; everything else is
       // left to the dialog (Escape, focus trap, etc.).
       if (open && key !== "?") return
+
+      // "?" is the global help toggle and stays live everywhere. Any other
+      // single key is suppressed while a dialog/menu/popover is open so it can't
+      // trigger navigation underneath the open layer.
+      if (key !== "?" && isOverlayOpen()) return
 
       const shortcut = keyMap.get(key)
       if (!shortcut?.run) return

--- a/src/components/shortcuts/shortcuts-provider.tsx
+++ b/src/components/shortcuts/shortcuts-provider.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { hasReservedModifier, isEditableTarget, normalizeKey } from "./keys"
+import { ShortcutsContext } from "./shortcuts-context"
+import { ShortcutsDialog } from "./shortcuts-dialog"
+import type { ReactNode } from "react"
+import type { Shortcut, ShortcutRegistration } from "./types"
+
+export function ShortcutsProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const [registrations, setRegistrations] = useState<
+    Array<ShortcutRegistration>
+  >([])
+
+  const registerShortcuts = useCallback(
+    (scopeId: string, shortcuts: Array<Shortcut>) => {
+      setRegistrations((current) => [
+        ...current.filter((registration) => registration.scopeId !== scopeId),
+        { scopeId, shortcuts },
+      ])
+
+      return () => {
+        setRegistrations((current) =>
+          current.filter((registration) => registration.scopeId !== scopeId)
+        )
+      }
+    },
+    []
+  )
+
+  const contextValue = useMemo(
+    () => ({
+      close: () => setOpen(false),
+      open: () => setOpen(true),
+      toggle: () => setOpen((current) => !current),
+      registerShortcuts,
+    }),
+    [registerShortcuts]
+  )
+
+  // The "?" shortcut lives globally so it works on every page and is always
+  // documented in the modal. Page-specific shortcuts are layered on top and win
+  // when they share a key.
+  const globalShortcuts = useMemo<Array<Shortcut>>(
+    () => [
+      {
+        id: "global.command-menu",
+        group: "Global",
+        keys: [],
+        label: "⌘ K",
+        description: "Open command menu",
+      },
+      {
+        id: "global.shortcuts",
+        group: "Global",
+        keys: ["?"],
+        description: "Show keyboard shortcuts",
+        run: () => setOpen((current) => !current),
+      },
+    ],
+    []
+  )
+
+  const shortcuts = useMemo(
+    () => [
+      ...globalShortcuts,
+      ...registrations.flatMap((registration) => registration.shortcuts),
+    ],
+    [globalShortcuts, registrations]
+  )
+
+  // Last write wins, so a page-specific shortcut transparently overrides a
+  // global one bound to the same key.
+  const keyMap = useMemo(() => {
+    const map = new Map<string, Shortcut>()
+
+    for (const shortcut of shortcuts) {
+      if (shortcut.enabled && !shortcut.enabled()) continue
+      if (!shortcut.run) continue
+
+      for (const key of shortcut.keys) {
+        map.set(normalizeKey(key), shortcut)
+      }
+    }
+
+    return map
+  }, [shortcuts])
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.isComposing) return
+      if (event.repeat) return
+      if (hasReservedModifier(event)) return
+      if (isEditableTarget(event.target)) return
+
+      const key = normalizeKey(event.key)
+
+      // While the modal is open only the toggle key is live; everything else is
+      // left to the dialog (Escape, focus trap, etc.).
+      if (open && key !== "?") return
+
+      const shortcut = keyMap.get(key)
+      if (!shortcut?.run) return
+
+      event.preventDefault()
+      Promise.resolve(shortcut.run({ event, key })).catch((error) => {
+        console.error(`Shortcut "${shortcut.id}" failed:`, error)
+      })
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [keyMap, open])
+
+  return (
+    <ShortcutsContext.Provider value={contextValue}>
+      {children}
+      <ShortcutsDialog
+        open={open}
+        onOpenChange={setOpen}
+        shortcuts={shortcuts}
+      />
+    </ShortcutsContext.Provider>
+  )
+}

--- a/src/components/shortcuts/types.ts
+++ b/src/components/shortcuts/types.ts
@@ -1,0 +1,42 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react"
+
+/**
+ * Groups shown (in this order) inside the keyboard shortcuts modal. Add a new
+ * group name here to surface a new page-specific section.
+ */
+export type ShortcutGroupName = "Global" | "Feedback"
+
+export type ShortcutRunContext = {
+  /** The normalized key that matched (lowercase for single letters). */
+  key: string
+  event: KeyboardEvent
+}
+
+export type Shortcut = {
+  id: string
+  group: ShortcutGroupName
+  /**
+   * The keys that trigger this shortcut. Single letters are matched
+   * case-insensitively; symbols/digits are matched verbatim (e.g. "?", "1").
+   * Leave empty for display-only entries (e.g. documenting "⌘K").
+   */
+  keys: Array<string>
+  /**
+   * Optional display override for the modal, e.g. "1–9" for a range. Falls back
+   * to the `keys` joined together.
+   */
+  label?: string
+  description: string
+  run?: (context: ShortcutRunContext) => void | Promise<void>
+  /** When provided and returns false, the shortcut is inert and hidden. */
+  enabled?: () => boolean
+  /** Hide from the modal while still being registered (rare). */
+  hidden?: boolean
+}
+
+export type ShortcutRegistration = {
+  scopeId: string
+  shortcuts: Array<Shortcut>
+}
+
+export type AnyKeyboardEvent = KeyboardEvent | ReactKeyboardEvent

--- a/src/components/shortcuts/use-shortcuts.ts
+++ b/src/components/shortcuts/use-shortcuts.ts
@@ -1,0 +1,43 @@
+import { useContext, useEffect } from "react"
+
+import { ShortcutsContext } from "./shortcuts-context"
+import type { Shortcut } from "./types"
+
+export function useShortcuts() {
+  const context = useContext(ShortcutsContext)
+
+  if (!context) {
+    throw new Error("useShortcuts must be used within ShortcutsProvider")
+  }
+
+  return {
+    close: context.close,
+    open: context.open,
+    toggle: context.toggle,
+  }
+}
+
+/**
+ * Registers a set of page-specific keyboard shortcuts for the lifetime of the
+ * calling component, keyed by `scopeId` (re-registering the same scope replaces
+ * it). Shortcuts are surfaced in the "?" shortcuts modal and matched globally
+ * (unless focus is inside an editable element).
+ *
+ * IMPORTANT: `shortcuts` is compared by reference. Always pass a memoized array
+ * (e.g. `useMemo`) — an inline array re-registers on every render, which loops
+ * provider state updates and re-renders the whole tree.
+ */
+export function useRegisterShortcuts(
+  scopeId: string,
+  shortcuts: Array<Shortcut>
+) {
+  const context = useContext(ShortcutsContext)
+
+  if (!context) {
+    throw new Error("useRegisterShortcuts must be used within ShortcutsProvider")
+  }
+
+  useEffect(() => {
+    return context.registerShortcuts(scopeId, shortcuts)
+  }, [context.registerShortcuts, scopeId, shortcuts])
+}

--- a/src/components/shortcuts/use-shortcuts.ts
+++ b/src/components/shortcuts/use-shortcuts.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react"
+import { useContext, useEffect, useRef } from "react"
 
 import { ShortcutsContext } from "./shortcuts-context"
 import type { Shortcut } from "./types"
@@ -23,9 +23,12 @@ export function useShortcuts() {
  * it). Shortcuts are surfaced in the "?" shortcuts modal and matched globally
  * (unless focus is inside an editable element).
  *
- * IMPORTANT: `shortcuts` is compared by reference. Always pass a memoized array
- * (e.g. `useMemo`) — an inline array re-registers on every render, which loops
- * provider state updates and re-renders the whole tree.
+ * Registration happens once per `scopeId` (on mount). The provider receives
+ * stable proxies whose `run`/`enabled` always delegate to the latest array via
+ * a ref, so passing a fresh array each render — even an inline literal — is
+ * safe and never loops provider state. The *structural* fields a proxy exposes
+ * (keys, label, description) are captured at registration time, so keep those
+ * static per scope; only `run`/`enabled` are expected to change over time.
  */
 export function useRegisterShortcuts(
   scopeId: string,
@@ -37,7 +40,25 @@ export function useRegisterShortcuts(
     throw new Error("useRegisterShortcuts must be used within ShortcutsProvider")
   }
 
+  const shortcutsRef = useRef(shortcuts)
+  shortcutsRef.current = shortcuts
+
+  const { registerShortcuts } = context
+
   useEffect(() => {
-    return context.registerShortcuts(scopeId, shortcuts)
-  }, [context.registerShortcuts, scopeId, shortcuts])
+    const proxies = shortcutsRef.current.map((shortcut, index) => ({
+      ...shortcut,
+      run: shortcut.run
+        ? (ctx: Parameters<NonNullable<Shortcut["run"]>>[0]) =>
+            shortcutsRef.current[index]?.run?.(ctx)
+        : undefined,
+      enabled: shortcut.enabled
+        ? () => shortcutsRef.current[index]?.enabled?.() ?? true
+        : undefined,
+    }))
+    return registerShortcuts(scopeId, proxies)
+    // Intentionally register once per scope; `run`/`enabled` stay fresh via the
+    // ref, so `shortcuts` is deliberately excluded from the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [registerShortcuts, scopeId])
 }

--- a/src/components/site-nav/user-dropdown.tsx
+++ b/src/components/site-nav/user-dropdown.tsx
@@ -4,6 +4,7 @@ import {
   Building2,
   ChevronDown,
   FolderKanban,
+  Keyboard,
   LogOut,
   Settings,
   User,
@@ -12,6 +13,7 @@ import type { ComponentType } from "react"
 import type { API } from "@/lib/api"
 
 import { NavButton } from "./nav-button"
+import { useShortcuts } from "@/components/shortcuts"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
   DropdownMenu,
@@ -30,6 +32,7 @@ export function UserDropdown({
   user: NonNullable<API["profile"]["findMyProfile"]>
 }) {
   const navigate = useNavigate()
+  const shortcuts = useShortcuts()
   const signOut = useMutation(useSignOutMutationOptions())
 
   return (
@@ -91,6 +94,10 @@ export function UserDropdown({
           }}
         >
           Account
+        </UserDropdownItem>
+        <DropdownMenuSeparator />
+        <UserDropdownItem icon={Keyboard} onClick={() => shortcuts.open()}>
+          Keyboard shortcuts
         </UserDropdownItem>
         <DropdownMenuSeparator />
         <UserDropdownItem

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -53,9 +53,10 @@ function CommandDialog({
       </DialogHeader>
       <DialogContent
         className={cn(
-          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0",
+          "top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0 duration-0 data-closed:animate-none data-open:animate-none",
           className
         )}
+        overlayClassName="duration-0 data-closed:animate-none data-open:animate-none"
         showCloseButton={showCloseButton}
       >
         <Command>{children}</Command>
@@ -154,7 +155,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none transition-colors in-data-[slot=dialog-content]:rounded-lg! hocus:bg-primary/10 hocus:text-foreground hocus:ring-1 hocus:ring-primary/25 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-primary/10 data-[selected=true]:text-foreground data-[selected=true]:ring-1 data-[selected=true]:ring-primary/25 dark:hocus:bg-foreground/12 dark:hocus:ring-foreground/20 dark:data-[selected=true]:bg-foreground/12 dark:data-[selected=true]:ring-foreground/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[selected=true]:*:[svg]:text-primary dark:data-[selected=true]:*:[svg]:text-foreground",
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! hocus:bg-primary/10 hocus:text-foreground hocus:ring-1 hocus:ring-primary/25 data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-primary/10 data-[selected=true]:text-foreground data-[selected=true]:ring-1 data-[selected=true]:ring-primary/25 dark:hocus:bg-foreground/12 dark:hocus:ring-foreground/20 dark:data-[selected=true]:bg-foreground/12 dark:data-[selected=true]:ring-foreground/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[selected=true]:*:[svg]:text-primary dark:data-[selected=true]:*:[svg]:text-foreground",
         className
       )}
       {...props}
@@ -173,7 +174,7 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground group-data-[selected=true]/command-item:text-foreground",
+        "ml-auto inline-flex min-w-6 items-center justify-center rounded border bg-muted px-1.5 py-0.5 font-sans text-xs font-medium text-muted-foreground/70 group-data-[selected=true]/command-item:text-muted-foreground/80",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,14 +40,16 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  overlayClassName,
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
+  overlayClassName?: string
   showCloseButton?: boolean
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(

--- a/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
@@ -1,20 +1,51 @@
-import { Link, useParams, useSearch } from '@tanstack/react-router';
+import { useMemo } from 'react';
+import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 
+import { useRegisterShortcuts } from '@/components/shortcuts';
 import { buttonVariants } from '@/components/ui/button';
 import { Icon, type IconName } from '@/icons';
 import { cn } from '@/lib/utils';
+
+// Single shortcut covering 1–9; the digit pressed selects the board at that
+// position in the list below (1 = All).
+const BOARD_SELECT_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
 export function BoardsNav({ boards }: { boards: any[] | null }) {
   const routePath = '/@{$org}/$project/feedback/';
   const { org, project } = useParams({ from: routePath });
   const { board: boardParam } = useSearch({ from: routePath });
+  const navigate = useNavigate();
+
+  const allBoards = useMemo(
+    () => [{ id: 'all', name: 'All', icon: 'box', slug: 'all' }, ...(boards ?? [])],
+    [boards]
+  );
+
+  const shortcuts = useMemo(
+    () => [
+      {
+        group: 'Feedback' as const,
+        id: 'feedback.select-board',
+        keys: BOARD_SELECT_KEYS,
+        label: '1–9',
+        description: 'Select board by position',
+        run: ({ key }: { key: string }) => {
+          const target = allBoards[Number(key) - 1];
+          if (!target) return;
+          navigate({
+            params: { org, project },
+            search: (prev) => ({ ...prev, board: target.slug }),
+            to: '/@{$org}/$project/feedback',
+          });
+        },
+      },
+    ],
+    [allBoards, navigate, org, project]
+  );
+
+  useRegisterShortcuts('feedback-boards', shortcuts);
 
   if (!boards) return <div>No boards</div>;
-
-  const allBoards = [
-    { id: 'all', name: 'All', icon: 'box', slug: 'all' },
-    ...boards,
-  ];
 
   return (
     <div className="flex flex-col gap-1">

--- a/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
@@ -10,7 +10,21 @@ import { cn } from '@/lib/utils';
 // position in the list below (1 = All).
 const BOARD_SELECT_KEYS = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
-export function BoardsNav({ boards }: { boards: any[] | null }) {
+// Only the fields this nav actually reads. The query returns richer board docs,
+// but a structural subset keeps the synthetic "All" entry valid and gives us
+// type-checked access to `slug`/`name`/`icon`.
+type FeedbackBoardNavItem = {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string | null;
+};
+
+export function BoardsNav({
+  boards,
+}: {
+  boards: FeedbackBoardNavItem[] | null;
+}) {
   const routePath = '/@{$org}/$project/feedback/';
   const { org, project } = useParams({ from: routePath });
   const { board: boardParam } = useSearch({ from: routePath });

--- a/src/routes/@{$org}/$project/feedback/-components/feedback-toolbar.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/feedback-toolbar.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useRouter, useSearch } from '@tanstack/react-router';
-import { X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 
+import { useRegisterCommands } from '@/components/command';
+import { useRegisterShortcuts } from '@/components/shortcuts';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -16,6 +18,8 @@ import Filter from '@/icons/filter';
 
 const FROM_ROUTE = '/@{$org}/$project/feedback/';
 const TO_ROUTE = '/@{$org}/$project/feedback';
+const SEARCH_INPUT_ID = 'feedback-search';
+const STATUS_FILTER_ID = 'status-filter';
 const STATUS_OPTIONS = [
   { label: 'All statuses', value: null },
   { label: 'Open', value: 'open' },
@@ -29,8 +33,12 @@ export function FeedbackToolbar() {
   const searchParams = useSearch({ from: FROM_ROUTE });
   const { search, status, board } = searchParams;
   const { org, project } = useParams({ from: FROM_ROUTE });
-  const [showFilters, setShowFilters] = useState(false);
+  // Visibility is driven solely by this state so the panel can always be
+  // toggled shut, even when a filter is active. It starts open if the user
+  // arrives with a filter already applied.
+  const [showFilters, setShowFilters] = useState(() => Boolean(status));
   const [searchTerm, setSearchTerm] = useState(!search ? '' : search);
+  const filtersPanelRef = useRef<HTMLDivElement>(null);
 
   const setSearchParams = (next: Omit<typeof searchParams, 'board'>) => {
     navigate({
@@ -51,6 +59,73 @@ export function FeedbackToolbar() {
 
   const hasActiveFilters = status;
 
+  const focusSearch = useCallback(() => {
+    const input = document.getElementById(SEARCH_INPUT_ID);
+    if (input instanceof HTMLInputElement) {
+      input.focus();
+      input.select();
+    }
+  }, []);
+
+  const toggleFilters = useCallback(() => {
+    setShowFilters((value) => {
+      const next = !value;
+      // When revealing the panel, move focus to the region so the next Tab
+      // lands on the first control inside it.
+      if (next) {
+        window.requestAnimationFrame(() => filtersPanelRef.current?.focus());
+      }
+      return next;
+    });
+  }, []);
+
+  const shortcuts = useMemo(
+    () => [
+      {
+        group: 'Feedback' as const,
+        id: 'feedback.search',
+        keys: ['f'],
+        description: 'Focus search',
+        run: focusSearch,
+      },
+      {
+        group: 'Feedback' as const,
+        id: 'feedback.filters',
+        keys: ['i'],
+        description: 'Toggle filters',
+        run: toggleFilters,
+      },
+    ],
+    [focusSearch, toggleFilters]
+  );
+
+  const commands = useMemo(
+    () => [
+      {
+        group: 'Feedback' as const,
+        icon: Search,
+        id: 'feedback.focus-search',
+        keywords: ['find', 'search', 'filter'],
+        shortcut: 'F',
+        title: 'Focus search',
+        run: focusSearch,
+      },
+      {
+        group: 'Feedback' as const,
+        icon: Filter,
+        id: 'feedback.toggle-filters',
+        keywords: ['filter', 'status', 'options'],
+        shortcut: 'I',
+        title: 'Toggle filters',
+        run: toggleFilters,
+      },
+    ],
+    [focusSearch, toggleFilters]
+  );
+
+  useRegisterShortcuts('feedback-toolbar', shortcuts);
+  useRegisterCommands('feedback-toolbar', commands);
+
   useEffect(() => {
     const timeout = window.setTimeout(() => {
       setSearchParams({
@@ -65,7 +140,7 @@ export function FeedbackToolbar() {
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-2">
           <Button
-            onClick={() => setShowFilters(!showFilters)}
+            onClick={toggleFilters}
             variant={showFilters || hasActiveFilters ? 'default' : 'outline'}
           >
             <Filter className="mr-2 h-4 w-4" />
@@ -96,6 +171,7 @@ export function FeedbackToolbar() {
 
         <div className="flex items-center gap-2">
           <Input
+            id={SEARCH_INPUT_ID}
             onChange={(event) => setSearchTerm(event.target.value)}
             placeholder="Search..."
             value={searchTerm}
@@ -103,11 +179,17 @@ export function FeedbackToolbar() {
         </div>
       </div>
 
-      {(showFilters || hasActiveFilters) ? (
-        <div className="rounded-lg border bg-muted/50 p-4">
+      {showFilters ? (
+        <div
+          ref={filtersPanelRef}
+          aria-label="Filters"
+          className="rounded-lg border bg-muted/50 p-4 outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          role="region"
+          tabIndex={-1}
+        >
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
             <div className="space-y-2">
-              <label className="text-muted-foreground" htmlFor="status-filter">
+              <label className="text-muted-foreground" htmlFor={STATUS_FILTER_ID}>
                 Status
               </label>
               <Select
@@ -119,7 +201,7 @@ export function FeedbackToolbar() {
                 }}
                 value={!status ? null : status}
               >
-                <SelectTrigger id="status-filter">
+                <SelectTrigger id={STATUS_FILTER_ID}>
                   <SelectValue placeholder="All statuses" />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -256,9 +256,6 @@ function FeedbackListRoute() {
                 >
                   <CirclePlusOutline size="16px" />
                   Add feedback
-                  <kbd className="ml-1 rounded border border-current px-1.5 py-px font-sans text-xs opacity-50">
-                    N
-                  </kbd>
                 </Link>
               </Button>
             </div>

--- a/src/routes/@{$org}/$project/feedback/index.tsx
+++ b/src/routes/@{$org}/$project/feedback/index.tsx
@@ -257,7 +257,7 @@ function FeedbackListRoute() {
                   <CirclePlusOutline size="16px" />
                   Add feedback
                   <kbd className="ml-1 rounded border border-current px-1.5 py-px font-sans text-xs opacity-50">
-                    ⌘O
+                    N
                   </kbd>
                 </Link>
               </Button>

--- a/src/routes/@{$org}/$project/feedback/route.tsx
+++ b/src/routes/@{$org}/$project/feedback/route.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router"
 
 import { useRegisterCommands } from "@/components/command"
+import { useRegisterShortcuts } from "@/components/shortcuts"
 import CirclePlusOutline from "@/icons/circle-plus-outline"
 import { projectTitle, titleMeta } from "@/lib/seo"
 
@@ -15,6 +16,16 @@ export const Route = createFileRoute("/@{$org}/$project/feedback")({
 function FeedbackRoute() {
   const navigate = useNavigate()
   const params = Route.useParams()
+
+  const goToNewFeedback = useCallback(
+    () =>
+      navigate({
+        params,
+        to: "/@{$org}/$project/feedback/new",
+      }),
+    [navigate, params]
+  )
+
   const commands = useMemo(
     () => [
       {
@@ -22,18 +33,29 @@ function FeedbackRoute() {
         icon: CirclePlusOutline,
         id: "feedback.add",
         keywords: ["create", "new", "request"],
+        shortcut: "N",
         title: "Add feedback",
-        run: () =>
-          navigate({
-            params,
-            to: "/@{$org}/$project/feedback/new",
-          }),
+        run: goToNewFeedback,
       },
     ],
-    [navigate, params]
+    [goToNewFeedback]
+  )
+
+  const shortcuts = useMemo(
+    () => [
+      {
+        group: "Feedback" as const,
+        id: "feedback.new",
+        keys: ["n"],
+        description: "New feedback",
+        run: goToNewFeedback,
+      },
+    ],
+    [goToNewFeedback]
   )
 
   useRegisterCommands("feedback", commands)
+  useRegisterShortcuts("feedback", shortcuts)
 
   return <Outlet />
 }


### PR DESCRIPTION
## What changed

- Added a reusable global shortcuts system with registration hooks, key normalization, editable-target guards, and a shortcuts help dialog.
- Wired the new shortcuts layer into app providers and the user dropdown so keyboard shortcuts can be discovered from the UI.
- Added feedback-page shortcuts and command palette entries for creating feedback, focusing search, toggling filters, and selecting boards by number.
- Polished command/dialog shortcut presentation so the command palette and shortcuts modal feel consistent.
- Updated `scripts/seed-convex-from-dev.mjs` to sanitize legacy feedback soft-delete fields out of exported JSONL before re-importing into the current schema.

## Why this changed

- The feedback UI now exposes faster keyboard-driven navigation and actions without stealing keystrokes from text inputs or interactive widgets.
- The seed script change prevents imports from failing when dev exports still contain legacy feedback fields that no longer exist in the current schema.

## Follow-up / test notes

- Tests not run in this PR flow.
- Worth validating the new single-key shortcuts in the feedback UI and confirming the seed script still handles both sanitized and already-clean exports.
