### PR TITLE
fix: use focus-visible for interactive controls

### DIFF
--- a/src/components/checkbox-button.tsx
+++ b/src/components/checkbox-button.tsx
@@ -7,7 +7,7 @@ import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const checkboxButtonVariants = cva(
-  "inline-flex items-center rounded-lg border border-input transition-all duration-200 hover:bg-muted/50 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
+  "inline-flex items-center rounded-lg border border-input transition-all duration-200 hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
   {
     variants: {
       size: {

--- a/src/components/editor/extensions/code-block-component.tsx
+++ b/src/components/editor/extensions/code-block-component.tsx
@@ -33,7 +33,7 @@ export function CodeBlockComponent({ node, updateAttributes }: NodeViewProps) {
   return (
     <NodeViewWrapper className="code-block-wrapper relative">
       <select
-        className="absolute top-2 right-2 z-10 cursor-pointer rounded border border-border bg-background/80 py-1 pr-2 pl-1 text-[10px] text-muted-foreground outline-none hover:bg-background hover:text-foreground focus:border-ring"
+        className="absolute top-2 right-2 z-10 cursor-pointer rounded border border-border bg-background/80 py-1 pr-2 pl-1 text-[10px] text-muted-foreground outline-none hover:bg-background hover:text-foreground focus-visible:border-ring"
         contentEditable={false}
         onChange={(event) => updateAttributes({ language: event.target.value })}
         value={language}

--- a/src/components/kino/common.tsx
+++ b/src/components/kino/common.tsx
@@ -6,13 +6,13 @@ import { FORM_LIMITS, normalizeSlugInput } from "@/lib/validation"
 import { cn } from "@/lib/utils"
 
 export const inputClassName =
-  "w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus:border-foreground/30 focus:ring-2 focus:ring-foreground/10"
+  "w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus-visible:border-foreground/30 focus-visible:ring-2 focus-visible:ring-foreground/10"
 
 export const textareaClassName =
-  "min-h-28 w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus:border-foreground/30 focus:ring-2 focus:ring-foreground/10"
+  "min-h-28 w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus-visible:border-foreground/30 focus-visible:ring-2 focus-visible:ring-foreground/10"
 
 export const selectClassName =
-  "w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus:border-foreground/30 focus:ring-2 focus:ring-foreground/10"
+  "w-full rounded-xl border border-border bg-background/80 px-3 py-2.5 text-sm outline-none transition focus-visible:border-foreground/30 focus-visible:ring-2 focus-visible:ring-foreground/10"
 
 export function PageFrame({
   children,

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -43,7 +43,7 @@ function Calendar({
         range_start: "rounded-l-md",
         root: cn("relative w-fit", classNames?.root),
         selected:
-          "rounded-md bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "rounded-md bg-primary text-primary-foreground hocus:bg-primary hocus:text-primary-foreground",
         today: "bg-accent text-accent-foreground",
         week: "mt-2 flex w-full",
         weekday:

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -70,7 +70,7 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[open]:bg-secondary">
+        <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:pointer-events-none data-[open]:bg-secondary">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>

--- a/src/routes/@{$org}/$project/roadmap/index.tsx
+++ b/src/routes/@{$org}/$project/roadmap/index.tsx
@@ -889,7 +889,7 @@ function RoadmapPage() {
               placeholder="Search roadmap…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full rounded-md border bg-muted/50 py-1.5 pr-3 pl-8 text-xs transition-colors placeholder:text-muted-foreground focus:border-ring focus:ring-1 focus:ring-ring focus:outline-none"
+              className="w-full rounded-md border bg-muted/50 py-1.5 pr-3 pl-8 text-xs transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
             />
           </div>
         </div>


### PR DESCRIPTION
## What changed
- replaced generic `focus:` ring and border styles with `focus-visible:` on several interactive controls
- updated the calendar selected-day styling to use `hocus:` for consistent hover/focus behavior
- applied the same keyboard-focus treatment to the roadmap search input and sheet close button

## Why
These components were showing focus styling on pointer interaction as well as keyboard navigation. Restricting those states to `focus-visible` keeps keyboard accessibility intact while reducing noisy visual states for mouse users.

## Test notes
- not run; visual/style-only changes
- recommend spot-checking keyboard tab navigation on the updated controls