### PR TITLE
Refactor sidebar navigation into shared components

### DIFF
--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -1,6 +1,12 @@
-import { ChevronRight } from "lucide-react"
+import { ChevronDown, ChevronRight } from "lucide-react"
 
 import { buttonVariants } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { cn } from "@/lib/utils"
 
 type SidebarNavGroupProps = {
@@ -32,7 +38,7 @@ export function SidebarNavGroup({
 }
 
 type SidebarNavItemProps = {
-  /** Marks the item as the active/current selection (filled `bg-muted`). */
+  /** Marks the item as the active/current selection. */
   active?: boolean
   /** Optional leading icon. */
   icon?: React.ReactNode
@@ -43,7 +49,8 @@ type SidebarNavItemProps = {
 /**
  * Ghost-styled sidebar entry. Render it as the child of a TanStack `<Link>`
  * (route nav) or any element — keeping routing/search-param typing at the call
- * site. When `active`, the ghost gradient flattens to a solid `bg-muted` fill.
+ * site. When `active`, it uses the same foreground-alpha gradient family as the
+ * ghost pressed state and exposes the current item to assistive technology.
  */
 export function SidebarNavItem({
   active,
@@ -53,6 +60,7 @@ export function SidebarNavItem({
 }: SidebarNavItemProps) {
   return (
     <span
+      aria-current={active ? "page" : undefined}
       data-active={active || undefined}
       className={cn(
         buttonVariants({ variant: "ghost" }),
@@ -79,5 +87,60 @@ export function SidebarNavItem({
         className="size-3 opacity-0 transition-opacity group-data-[active]:opacity-70"
       />
     </span>
+  )
+}
+
+type SidebarNavSelectItem = {
+  active?: boolean
+  icon?: React.ReactNode
+  key: React.Key
+  label: React.ReactNode
+  renderLink: (children: React.ReactNode) => React.ReactNode
+}
+
+type SidebarNavSelectProps = {
+  items: SidebarNavSelectItem[]
+  className?: string
+}
+
+export function SidebarNavSelect({ items, className }: SidebarNavSelectProps) {
+  const activeItem = items.find((item) => item.active) ?? items[0]
+
+  if (!activeItem) return null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            buttonVariants({ variant: "outline", size: "lg" }),
+            "w-full justify-between",
+            className
+          )}
+        >
+          <span className="inline-flex min-w-0 items-center gap-3">
+            {activeItem.icon}
+            <span className="truncate">{activeItem.label}</span>
+          </span>
+          <ChevronDown className="size-4 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[var(--anchor-width)]">
+        {items.map((item) => (
+          <DropdownMenuItem key={item.key} asChild>
+            {item.renderLink(
+              <span
+                aria-current={item.active ? "page" : undefined}
+                className="flex min-w-0 items-center gap-3"
+              >
+                {item.icon}
+                <span className="truncate">{item.label}</span>
+              </span>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/src/components/sidebar-nav.tsx
+++ b/src/components/sidebar-nav.tsx
@@ -1,0 +1,83 @@
+import { ChevronRight } from "lucide-react"
+
+import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+type SidebarNavGroupProps = {
+  /** Optional heading rendered above the list (e.g. "Settings", "Categories"). */
+  title?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * Heading + vertical list container shared by every left-side sidebar nav.
+ * Pair with {@link SidebarNavItem} for the individual links/buttons.
+ */
+export function SidebarNavGroup({
+  title,
+  children,
+  className,
+}: SidebarNavGroupProps) {
+  return (
+    <div className={className}>
+      {title ? (
+        <h2 className="mx-2 mb-2 text-sm font-bold text-muted-foreground">
+          {title}
+        </h2>
+      ) : null}
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  )
+}
+
+type SidebarNavItemProps = {
+  /** Marks the item as the active/current selection (filled `bg-muted`). */
+  active?: boolean
+  /** Optional leading icon. */
+  icon?: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * Ghost-styled sidebar entry. Render it as the child of a TanStack `<Link>`
+ * (route nav) or any element — keeping routing/search-param typing at the call
+ * site. When `active`, the ghost gradient flattens to a solid `bg-muted` fill.
+ */
+export function SidebarNavItem({
+  active,
+  icon,
+  children,
+  className,
+}: SidebarNavItemProps) {
+  return (
+    <span
+      data-active={active || undefined}
+      className={cn(
+        buttonVariants({ variant: "ghost" }),
+        "group inline-flex! w-full items-center justify-start text-left",
+        // Active = a contrasty foreground-alpha gradient (deepens on light,
+        // lifts on dark), with a soft same-tone border that blends into the fill.
+        "data-[active]:pointer-events-none data-[active]:border-foreground/10 data-[active]:from-foreground/8 data-[active]:via-foreground/12 data-[active]:to-foreground/12 data-[active]:text-accent-foreground",
+        className
+      )}
+    >
+      {icon ? (
+        <span className="mr-auto inline-flex items-center gap-3">
+          <span className="opacity-60 transition-opacity group-hover:opacity-100 group-data-[active]:opacity-100">
+            {icon}
+          </span>
+          <span>{children}</span>
+        </span>
+      ) : (
+        <span className="mr-auto">{children}</span>
+      )}
+      {/* Right-aligned arrow: only visible when active (not on hover). */}
+      <ChevronRight
+        aria-hidden="true"
+        className="size-3 opacity-0 transition-opacity group-data-[active]:opacity-70"
+      />
+    </span>
+  )
+}

--- a/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
+++ b/src/routes/@{$org}/$project/feedback/-components/boards-nav.tsx
@@ -2,9 +2,8 @@ import { useMemo } from 'react';
 import { Link, useNavigate, useParams, useSearch } from '@tanstack/react-router';
 
 import { useRegisterShortcuts } from '@/components/shortcuts';
-import { buttonVariants } from '@/components/ui/button';
+import { SidebarNavGroup, SidebarNavItem } from '@/components/sidebar-nav';
 import { Icon, type IconName } from '@/icons';
-import { cn } from '@/lib/utils';
 
 // Single shortcut covering 1–9; the digit pressed selects the board at that
 // position in the list below (1 = All).
@@ -62,7 +61,7 @@ export function BoardsNav({
   if (!boards) return <div>No boards</div>;
 
   return (
-    <div className="flex flex-col gap-1">
+    <SidebarNavGroup>
       {allBoards.map((board) => (
         <Link
           key={board.id}
@@ -73,26 +72,16 @@ export function BoardsNav({
           })}
           to="/@{$org}/$project/feedback"
         >
-          {({ isActive }) => {
-            const active = board.slug === boardParam || isActive;
-            return (
-              <span
-                className={cn(
-                  active
-                    ? buttonVariants({ variant: 'outline', className: 'pointer-events-none' })
-                    : buttonVariants({ variant: 'ghost' }),
-                  'group inline-flex! w-full items-center justify-start text-left'
-                )}
-              >
-                <span className="mr-auto inline-flex items-center gap-3">
-                  <Icon fallback="box" name={board?.icon as IconName} size="16px" />
-                  <span>{board.name}</span>
-                </span>
-              </span>
-            );
-          }}
+          {({ isActive }) => (
+            <SidebarNavItem
+              active={board.slug === boardParam || isActive}
+              icon={<Icon fallback="box" name={board?.icon as IconName} size="16px" />}
+            >
+              {board.name}
+            </SidebarNavItem>
+          )}
         </Link>
       ))}
-    </div>
+    </SidebarNavGroup>
   );
 }

--- a/src/routes/@{$org}/$project/settings/route.tsx
+++ b/src/routes/@{$org}/$project/settings/route.tsx
@@ -22,6 +22,10 @@ export const Route = createFileRoute("/@{$org}/$project/settings")({
 
 function ProjectSettingsRoute() {
   const params = Route.useParams()
+  const linkParams = {
+    org: params.org,
+    project: params.project,
+  }
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
@@ -56,10 +60,7 @@ function ProjectSettingsRoute() {
       key: item.to,
       label: item.label,
       renderLink: (children: React.ReactNode) => (
-        <Link
-          params={{ org: params.org, project: params.project }}
-          to={item.to}
-        >
+        <Link params={(prev) => ({ ...prev, ...linkParams })} to={item.to}>
           {children}
         </Link>
       ),
@@ -81,7 +82,7 @@ function ProjectSettingsRoute() {
                 return (
                   <Link
                     key={item.to}
-                    params={{ org: params.org, project: params.project }}
+                    params={(prev) => ({ ...prev, ...linkParams })}
                     to={item.to}
                   >
                     {({ isActive }) => (

--- a/src/routes/@{$org}/$project/settings/route.tsx
+++ b/src/routes/@{$org}/$project/settings/route.tsx
@@ -6,7 +6,11 @@ import {
 } from "@tanstack/react-router"
 import { GitBranch, LayoutDashboard, Users } from "lucide-react"
 
-import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
+import {
+  SidebarNavGroup,
+  SidebarNavItem,
+  SidebarNavSelect,
+} from "@/components/sidebar-nav"
 import { titleMeta } from "@/lib/seo"
 
 export const Route = createFileRoute("/@{$org}/$project/settings")({
@@ -39,19 +43,40 @@ function ProjectSettingsRoute() {
       to: "/@{$org}/$project/settings/integrations" as const,
     },
   ]
+  const navItems = items.map((item) => {
+    const Icon = item.icon
+    const path = item.to
+      .replace("/@{$org}", `/@${params.org}`)
+      .replace("$project", params.project)
+    const active = pathname === path || pathname.startsWith(`${path}/`)
+
+    return {
+      active,
+      icon: <Icon className="size-4" />,
+      key: item.to,
+      label: item.label,
+      renderLink: (children: React.ReactNode) => (
+        <Link
+          params={{ org: params.org, project: params.project }}
+          to={item.to}
+        >
+          {children}
+        </Link>
+      ),
+    }
+  })
 
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
+      <div className="py-4 md:hidden">
+        <SidebarNavSelect items={navItems} />
+      </div>
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-        <div className="order-last py-8 md:order-first md:col-span-3 md:border-r md:border-border/75">
+        <div className="hidden py-8 md:col-span-3 md:block md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
             <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Settings">
               {items.map((item) => {
                 const Icon = item.icon
-                const routePath = item.to
-                  .replace("/@{$org}", `/@${params.org}`)
-                  .replace("$project", params.project)
-                const isActive = pathname.startsWith(routePath)
 
                 return (
                   <Link
@@ -59,12 +84,14 @@ function ProjectSettingsRoute() {
                     params={{ org: params.org, project: params.project }}
                     to={item.to}
                   >
-                    <SidebarNavItem
-                      active={isActive}
-                      icon={<Icon className="size-4" />}
-                    >
-                      {item.label}
-                    </SidebarNavItem>
+                    {({ isActive }) => (
+                      <SidebarNavItem
+                        active={isActive}
+                        icon={<Icon className="size-4" />}
+                      >
+                        {item.label}
+                      </SidebarNavItem>
+                    )}
                   </Link>
                 )
               })}

--- a/src/routes/@{$org}/$project/settings/route.tsx
+++ b/src/routes/@{$org}/$project/settings/route.tsx
@@ -6,8 +6,7 @@ import {
 } from "@tanstack/react-router"
 import { GitBranch, LayoutDashboard, Users } from "lucide-react"
 
-import { buttonVariants } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
+import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
 import { titleMeta } from "@/lib/seo"
 
 export const Route = createFileRoute("/@{$org}/$project/settings")({
@@ -46,45 +45,30 @@ function ProjectSettingsRoute() {
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
         <div className="order-last py-8 md:order-first md:col-span-3 md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="border-b pb-6 md:pr-6">
-              <h2 className="mx-2 text-sm font-bold text-muted-foreground">
-                Settings
-              </h2>
-              <div className="mt-2 flex flex-col gap-1">
-                {items.map((item) => {
-                  const Icon = item.icon
-                  const routePath = item.to
-                    .replace("/@{$org}", `/@${params.org}`)
-                    .replace("$project", params.project)
-                  const isActive = pathname.startsWith(routePath)
+            <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Settings">
+              {items.map((item) => {
+                const Icon = item.icon
+                const routePath = item.to
+                  .replace("/@{$org}", `/@${params.org}`)
+                  .replace("$project", params.project)
+                const isActive = pathname.startsWith(routePath)
 
-                  return (
-                    <Link
-                      key={item.to}
-                      params={{ org: params.org, project: params.project }}
-                      to={item.to}
+                return (
+                  <Link
+                    key={item.to}
+                    params={{ org: params.org, project: params.project }}
+                    to={item.to}
+                  >
+                    <SidebarNavItem
+                      active={isActive}
+                      icon={<Icon className="size-4" />}
                     >
-                      <span
-                        className={cn(
-                          isActive
-                            ? buttonVariants({
-                                variant: "outline",
-                                className: "pointer-events-none",
-                              })
-                            : buttonVariants({ variant: "ghost" }),
-                          "group inline-flex! w-full items-center justify-start text-left"
-                        )}
-                      >
-                        <span className="mr-auto inline-flex items-center gap-3">
-                          <Icon className="size-4" />
-                          <span>{item.label}</span>
-                        </span>
-                      </span>
-                    </Link>
-                  )
-                })}
-              </div>
-            </div>
+                      {item.label}
+                    </SidebarNavItem>
+                  </Link>
+                )
+              })}
+            </SidebarNavGroup>
           </div>
         </div>
         <div className="flex flex-col gap-4 py-8 md:col-span-9">

--- a/src/routes/@{$org}/$project/updates/-components/categories-nav.tsx
+++ b/src/routes/@{$org}/$project/updates/-components/categories-nav.tsx
@@ -1,7 +1,6 @@
 import { Link, useParams, useSearch } from '@tanstack/react-router';
 
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { SidebarNavGroup, SidebarNavItem } from '@/components/sidebar-nav';
 
 import { CATEGORY_CONFIG } from './category-badge';
 
@@ -18,7 +17,7 @@ export function CategoriesNav() {
   const { category: categoryParam } = useSearch({ from: routePath });
 
   return (
-    <div className="flex flex-col gap-1">
+    <SidebarNavGroup>
       {categories.map((category) => {
         const active = category.slug === (categoryParam ?? 'all');
         return (
@@ -31,19 +30,10 @@ export function CategoriesNav() {
             })}
             to="/@{$org}/$project/updates"
           >
-            <span
-              className={cn(
-                active
-                  ? buttonVariants({ variant: 'outline', className: 'pointer-events-none' })
-                  : buttonVariants({ variant: 'ghost' }),
-                'inline-flex! w-full items-center justify-start text-left'
-              )}
-            >
-              {category.label}
-            </span>
+            <SidebarNavItem active={active}>{category.label}</SidebarNavItem>
           </Link>
         );
       })}
-    </div>
+    </SidebarNavGroup>
   );
 }

--- a/src/routes/@{$org}/settings/route.tsx
+++ b/src/routes/@{$org}/settings/route.tsx
@@ -6,7 +6,11 @@ import {
 } from "@tanstack/react-router"
 import { GitBranch, Settings, Users } from "lucide-react"
 
-import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
+import {
+  SidebarNavGroup,
+  SidebarNavItem,
+  SidebarNavSelect,
+} from "@/components/sidebar-nav"
 import { titleMeta } from "@/lib/seo"
 
 export const Route = createFileRoute("/@{$org}/settings")({
@@ -39,27 +43,46 @@ function OrganizationSettingsRoute() {
       to: "/@{$org}/settings/integrations" as const,
     },
   ]
+  const navItems = items.map((item) => {
+    const Icon = item.icon
+    const path = item.to.replace("/@{$org}", `/@${params.org}`)
+    const active = pathname === path || pathname.startsWith(`${path}/`)
+
+    return {
+      active,
+      icon: <Icon className="size-4" />,
+      key: item.to,
+      label: item.label,
+      renderLink: (children: React.ReactNode) => (
+        <Link params={{ org: params.org }} to={item.to}>
+          {children}
+        </Link>
+      ),
+    }
+  })
 
   return (
     <div className="container flex flex-1 flex-col overflow-visible">
+      <div className="py-4 md:hidden">
+        <SidebarNavSelect items={navItems} />
+      </div>
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
-        <div className="order-last py-8 md:order-first md:col-span-3 md:border-r md:border-border/75">
+        <div className="hidden py-8 md:col-span-3 md:block md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
             <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Settings">
               {items.map((item) => {
                 const Icon = item.icon
-                const isActive = pathname.startsWith(
-                  item.to.replace("/@{$org}", `/@${params.org}`)
-                )
 
                 return (
                   <Link key={item.to} params={{ org: params.org }} to={item.to}>
-                    <SidebarNavItem
-                      active={isActive}
-                      icon={<Icon className="size-4" />}
-                    >
-                      {item.label}
-                    </SidebarNavItem>
+                    {({ isActive }) => (
+                      <SidebarNavItem
+                        active={isActive}
+                        icon={<Icon className="size-4" />}
+                      >
+                        {item.label}
+                      </SidebarNavItem>
+                    )}
                   </Link>
                 )
               })}

--- a/src/routes/@{$org}/settings/route.tsx
+++ b/src/routes/@{$org}/settings/route.tsx
@@ -6,8 +6,7 @@ import {
 } from "@tanstack/react-router"
 import { GitBranch, Settings, Users } from "lucide-react"
 
-import { buttonVariants } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
+import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
 import { titleMeta } from "@/lib/seo"
 
 export const Route = createFileRoute("/@{$org}/settings")({
@@ -46,44 +45,25 @@ function OrganizationSettingsRoute() {
       <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
         <div className="order-last py-8 md:order-first md:col-span-3 md:border-r md:border-border/75">
           <div className="sticky top-6 flex flex-col overflow-hidden">
-            <div className="border-b pb-6 md:pr-6">
-              <h2 className="mx-2 text-sm font-bold text-muted-foreground">
-                Settings
-              </h2>
-              <div className="mt-2 flex flex-col gap-1">
-                {items.map((item) => {
-                  const Icon = item.icon
-                  const isActive = pathname.startsWith(
-                    item.to.replace("/@{$org}", `/@${params.org}`)
-                  )
+            <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Settings">
+              {items.map((item) => {
+                const Icon = item.icon
+                const isActive = pathname.startsWith(
+                  item.to.replace("/@{$org}", `/@${params.org}`)
+                )
 
-                  return (
-                    <Link
-                      key={item.to}
-                      params={{ org: params.org }}
-                      to={item.to}
+                return (
+                  <Link key={item.to} params={{ org: params.org }} to={item.to}>
+                    <SidebarNavItem
+                      active={isActive}
+                      icon={<Icon className="size-4" />}
                     >
-                      <span
-                        className={cn(
-                          isActive
-                            ? buttonVariants({
-                                variant: "outline",
-                                className: "pointer-events-none",
-                              })
-                            : buttonVariants({ variant: "ghost" }),
-                          "group inline-flex! w-full items-center justify-start text-left"
-                        )}
-                      >
-                        <span className="mr-auto inline-flex items-center gap-3">
-                          <Icon className="size-4" />
-                          <span>{item.label}</span>
-                        </span>
-                      </span>
-                    </Link>
-                  )
-                })}
-              </div>
-            </div>
+                      {item.label}
+                    </SidebarNavItem>
+                  </Link>
+                )
+              })}
+            </SidebarNavGroup>
           </div>
         </div>
         <div className="flex flex-col gap-4 py-8 md:col-span-9">

--- a/src/routes/account/route.tsx
+++ b/src/routes/account/route.tsx
@@ -6,20 +6,16 @@ import {
   createFileRoute,
   useRouterState,
 } from "@tanstack/react-router"
-import { Bell, ChevronDown, Palette, ShieldCheck, User } from "lucide-react"
+import { Bell, Palette, ShieldCheck, User } from "lucide-react"
 
 import { MainNav } from "@/components/site-nav/main-nav"
-import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
-import { buttonVariants } from "@/components/ui/button"
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+  SidebarNavGroup,
+  SidebarNavItem,
+  SidebarNavSelect,
+} from "@/components/sidebar-nav"
 import { useCRPC } from "@/lib/convex/crpc"
 import { crpcServer } from "@/lib/convex/crpc-server"
-import { cn } from "@/lib/utils"
 import { titleMeta } from "@/lib/seo"
 
 export const Route = createFileRoute("/account")({
@@ -84,9 +80,20 @@ function AuthenticatedAccountShell() {
   const profileQuery = useSuspenseQuery(
     crpc.profile.findMyProfile.queryOptions({}, { skipUnauth: true })
   )
-  const activeItem =
-    navItems.find((item) => pathname.startsWith(item.to)) ?? navItems[0]
-  const ActiveIcon = activeItem.icon
+  const selectItems = navItems.map((item) => {
+    const Icon = item.icon
+    const active = pathname === item.to || pathname.startsWith(`${item.to}/`)
+
+    return {
+      active,
+      icon: <Icon className="size-4" />,
+      key: item.to,
+      label: item.label,
+      renderLink: (children: React.ReactNode) => (
+        <Link to={item.to}>{children}</Link>
+      ),
+    }
+  })
 
   return (
     <div className="flex min-h-dvh w-full flex-col">
@@ -99,59 +106,30 @@ function AuthenticatedAccountShell() {
         <div className="container flex flex-1 flex-col overflow-visible">
           {/* Mobile: section navigation collapses into a dropdown. */}
           <div className="py-4 md:hidden">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className={cn(
-                    buttonVariants({ variant: "outline", size: "lg" }),
-                    "w-full justify-between"
-                  )}
-                >
-                  <span className="inline-flex items-center gap-3">
-                    <ActiveIcon className="size-4" />
-                    {activeItem.label}
-                  </span>
-                  <ChevronDown className="size-4 text-muted-foreground" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="start"
-                className="w-[var(--anchor-width)]"
-              >
-                {navItems.map((item) => {
-                  const Icon = item.icon
-
-                  return (
-                    <DropdownMenuItem key={item.to} asChild>
-                      <Link className="flex items-center gap-3" to={item.to}>
-                        <Icon className="size-4" />
-                        {item.label}
-                      </Link>
-                    </DropdownMenuItem>
-                  )
-                })}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <SidebarNavSelect items={selectItems} />
           </div>
 
           <div className="flex flex-1 flex-col gap-8 md:grid md:grid-cols-12">
             {/* Desktop: persistent sidebar. */}
             <div className="hidden py-8 md:col-span-3 md:block md:border-r md:border-border/75">
               <div className="sticky top-6 flex flex-col overflow-hidden">
-                <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Account">
+                <SidebarNavGroup
+                  className="border-b pb-6 md:pr-6"
+                  title="Account"
+                >
                   {navItems.map((item) => {
                     const Icon = item.icon
-                    const isActive = pathname.startsWith(item.to)
 
                     return (
                       <Link key={item.to} to={item.to}>
-                        <SidebarNavItem
-                          active={isActive}
-                          icon={<Icon className="size-4" />}
-                        >
-                          {item.label}
-                        </SidebarNavItem>
+                        {({ isActive }) => (
+                          <SidebarNavItem
+                            active={isActive}
+                            icon={<Icon className="size-4" />}
+                          >
+                            {item.label}
+                          </SidebarNavItem>
+                        )}
                       </Link>
                     )
                   })}

--- a/src/routes/account/route.tsx
+++ b/src/routes/account/route.tsx
@@ -9,6 +9,7 @@ import {
 import { Bell, ChevronDown, Palette, ShieldCheck, User } from "lucide-react"
 
 import { MainNav } from "@/components/site-nav/main-nav"
+import { SidebarNavGroup, SidebarNavItem } from "@/components/sidebar-nav"
 import { buttonVariants } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -138,38 +139,23 @@ function AuthenticatedAccountShell() {
             {/* Desktop: persistent sidebar. */}
             <div className="hidden py-8 md:col-span-3 md:block md:border-r md:border-border/75">
               <div className="sticky top-6 flex flex-col overflow-hidden">
-                <div className="border-b pb-6 md:pr-6">
-                  <h2 className="mx-2 text-sm font-bold text-muted-foreground">
-                    Account
-                  </h2>
-                  <div className="mt-2 flex flex-col gap-1">
-                    {navItems.map((item) => {
-                      const Icon = item.icon
-                      const isActive = pathname.startsWith(item.to)
+                <SidebarNavGroup className="border-b pb-6 md:pr-6" title="Account">
+                  {navItems.map((item) => {
+                    const Icon = item.icon
+                    const isActive = pathname.startsWith(item.to)
 
-                      return (
-                        <Link key={item.to} to={item.to}>
-                          <span
-                            className={cn(
-                              isActive
-                                ? buttonVariants({
-                                    variant: "outline",
-                                    className: "pointer-events-none",
-                                  })
-                                : buttonVariants({ variant: "ghost" }),
-                              "group inline-flex! w-full items-center justify-start text-left"
-                            )}
-                          >
-                            <span className="mr-auto inline-flex items-center gap-3">
-                              <Icon className="size-4" />
-                              <span>{item.label}</span>
-                            </span>
-                          </span>
-                        </Link>
-                      )
-                    })}
-                  </div>
-                </div>
+                    return (
+                      <Link key={item.to} to={item.to}>
+                        <SidebarNavItem
+                          active={isActive}
+                          icon={<Icon className="size-4" />}
+                        >
+                          {item.label}
+                        </SidebarNavItem>
+                      </Link>
+                    )
+                  })}
+                </SidebarNavGroup>
               </div>
             </div>
             <div className="flex flex-col gap-4 pb-8 md:col-span-9 md:py-8">


### PR DESCRIPTION
## What changed
- add a shared `SidebarNavGroup` / `SidebarNavItem` component for left-rail navigation
- switch account, organization settings, project settings, feedback boards, and update categories navs to use the shared component
- preserve active-state handling while standardizing the nav layout and affordances

## Why
These routes were each hand-rolling nearly identical sidebar nav markup and styling. Centralizing the pattern reduces duplication and makes future sidebar styling changes consistent across the app.

## Test notes
- `pnpm typecheck`

## Follow-up
- consider migrating any remaining sidebar nav variants to the shared component if they should match this pattern