### PR TITLE
fix(deploy): run aggregate backfill on prod/preview deploys via kitcn deploy

### DIFF
--- a/scripts/cloudflare-build.sh
+++ b/scripts/cloudflare-build.sh
@@ -31,7 +31,12 @@ if [ "$branch" = "$production_branch" ]; then
   fi
 
   export CONVEX_DEPLOY_KEY="$CONVEX_PROD_DEPLOY_KEY"
-  npx convex deploy \
+  # Use `kitcn deploy` (not `convex deploy`) so that, after pushing schema +
+  # functions, kitcn runs pending migrations and the aggregateIndex/rankIndex
+  # backfill against the just-deployed deployment. Plain `convex deploy` skips
+  # this, leaving any newly added aggregate index in BUILDING — which makes
+  # ORM count()/aggregate() reads throw COUNT_INDEX_BUILDING in production.
+  npx kitcn deploy \
     --cmd "$build_cmd" \
     --cmd-url-env-var-name VITE_CONVEX_URL
 else
@@ -41,7 +46,9 @@ else
   fi
 
   export CONVEX_DEPLOY_KEY="$CONVEX_PREVIEW_DEPLOY_KEY"
-  npx convex deploy \
+  # `kitcn deploy` also runs migrations + aggregate backfill against the preview
+  # deployment (targeted via --preview-name) after the convex push.
+  npx kitcn deploy \
     --preview-name "$preview_name" \
     --cmd "$build_cmd" \
     --cmd-url-env-var-name VITE_CONVEX_URL


### PR DESCRIPTION
## Problem

The Updates page was throwing in production:

```
Uncaught Error: COUNT_INDEX_BUILDING: aggregateIndex 'updateEmote.by_updateId_content' is BUILDING. Run aggregateBackfill until READY.
```

`update.ts` serves heart/comment counts via the kitcn ORM `count()`, which is backed by the `updateEmote.by_updateId_content` aggregate index. Production deploys ran plain `npx convex deploy`, which pushes schema + functions but **does not backfill** kitcn aggregate/rank indexes. So the newly added aggregate index landed in prod stuck in `BUILDING`, and every `count()` read threw `COUNT_INDEX_BUILDING`, crashing the page.

(The live prod index has already been backfilled to `READY` out-of-band, so the acute incident is resolved — this PR fixes the deploy pipeline so it can't recur.)

## Fix

Switch both the prod and preview branches of `scripts/cloudflare-build.sh` from `convex deploy` to `kitcn deploy`. `kitcn deploy` wraps `convex deploy` and then runs pending migrations + the `aggregateBackfill` flow against the just-deployed deployment (preview targeted automatically via `--preview-name`, which `convex run` supports as a hidden flag).

- Deploy-time backfill runs with `wait` + `strict`, so a failed/timed-out backfill fails the build instead of silently shipping a `BUILDING` index.
- No `defineMigration` migrations exist today, so the migration step is a no-op.

## Verification

- Confirmed prod aggregate state is `READY` (`generated/server:aggregateBackfill` returns `skippedReady: 2`).
- Pushed this branch; the **Cloudflare preview build (`Workers Builds: kino`) completed successfully**, exercising the new `kitcn deploy --preview-name` + strict backfill path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)