### PR TITLE
Add PostHog client monitoring and sourcemap uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@opentelemetry/api": "1.9.0",
+    "@posthog/react": "^1.10.3",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-devtools": "^0.10.0",
@@ -67,6 +68,7 @@
     "kitcn": "0.15.0",
     "lowlight": "^3.3.0",
     "lucide-react": "^1.16.0",
+    "posthog-js": "^1.393.5",
     "react": "^19.2.4",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.4",
@@ -83,6 +85,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.38.0",
     "@edge-runtime/vm": "^5.0.0",
+    "@posthog/cli": "^0.7.33",
     "@tanstack/devtools-vite": "^0.6.0",
     "@tanstack/eslint-config": "^0.4.0",
     "@testing-library/dom": "^10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@opentelemetry/api':
         specifier: 1.9.0
         version: 1.9.0
+      '@posthog/react':
+        specifier: ^1.10.3
+        version: 1.10.3(@types/react@19.2.14)(posthog-js@1.393.5)(react@19.2.6)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
@@ -107,6 +110,9 @@ importers:
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
+      posthog-js:
+        specifier: ^1.393.5
+        version: 1.393.5
       react:
         specifier: ^19.2.4
         version: 19.2.6
@@ -150,6 +156,9 @@ importers:
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
+      '@posthog/cli':
+        specifier: ^0.7.33
+        version: 0.7.33
       '@tanstack/devtools-vite':
         specifier: ^0.6.0
         version: 0.6.1(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -1643,6 +1652,27 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/cli@0.7.33':
+    resolution: {integrity: sha512-shiGauwcH64wBVD08rXcAaLyOdCbstjlwdDQ6jgWX39cZZnf8EpPqwywJz9me83EFIij2Ky4j7IxDutyADiOgQ==}
+    engines: {node: '>=14.14', npm: '>=6'}
+    hasBin: true
+
+  '@posthog/core@1.37.3':
+    resolution: {integrity: sha512-Dvw4CTlRVH4K5ag/B8YIHgG4E27w43MCUsXpn1iKQHIggIMN3Shq9whG4Omm3OvXPF+VikBTmpyMKUjckPxw+g==}
+
+  '@posthog/react@1.10.3':
+    resolution: {integrity: sha512-Qu//fGQmVlX0B9kTA3LLg67e7AYLEmeuA0Bf1qSyUM0uUILcRQGjQezhNQPLYSTakOqvXEnl6fM2iQBF6Toxrw==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      posthog-js: '>=1.257.2'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@posthog/types@1.391.1':
+    resolution: {integrity: sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -2681,6 +2711,9 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -3272,6 +3305,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -3414,6 +3450,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3712,6 +3751,9 @@ packages:
 
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4553,9 +4595,15 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.393.5:
+    resolution: {integrity: sha512-gYIULHldc2MDmeXE75ykRJYlZ7Q75jAYAzxr0vjD3wnfW1CZoQxV6YydaPRcDyWllJfO4UJPSQJfk9s1UIMa9A==}
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4680,6 +4728,9 @@ packages:
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5372,6 +5423,9 @@ packages:
 
   web-vitals@5.2.0:
     resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -6820,6 +6874,23 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/cli@0.7.33':
+    dependencies:
+      detect-libc: 2.1.2
+
+  '@posthog/core@1.37.3':
+    dependencies:
+      '@posthog/types': 1.391.1
+
+  '@posthog/react@1.10.3(@types/react@19.2.14)(posthog-js@1.393.5)(react@19.2.6)':
+    dependencies:
+      posthog-js: 1.393.5
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@posthog/types@1.391.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
@@ -7879,6 +7950,9 @@ snapshots:
 
   '@types/statuses@2.0.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.6': {}
@@ -8419,6 +8493,8 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-js@3.49.0: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -8533,6 +8609,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -8959,6 +9039,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fetchdts@0.1.7: {}
+
+  fflate@0.4.8: {}
 
   figures@6.1.0:
     dependencies:
@@ -9699,7 +9781,20 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.393.5:
+    dependencies:
+      '@posthog/core': 1.37.3
+      '@posthog/types': 1.391.1
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   powershell-utils@0.1.0: {}
+
+  preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
 
@@ -9803,6 +9898,8 @@ snapshots:
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10536,6 +10633,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.2.0: {}
+
+  web-vitals@5.3.0: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/scripts/cloudflare-build.sh
+++ b/scripts/cloudflare-build.sh
@@ -19,9 +19,19 @@ preview_name="$(sh scripts/preview-name.sh "$branch" 48)"
 if [ "$branch" = "$production_branch" ]; then
   export GATEWAY_URL="${GATEWAY_URL_PRODUCTION:-}"
   export GATEWAY_ADMIN_TOKEN="${GATEWAY_ADMIN_TOKEN_PRODUCTION:-}"
+  export VITE_POSTHOG_PROJECT_TOKEN="${POSTHOG_PROJECT_TOKEN_PRODUCTION:-}"
+  export VITE_POSTHOG_HOST="${POSTHOG_HOST_PRODUCTION:-}"
+  export POSTHOG_CLI_API_KEY="${POSTHOG_CLI_API_KEY_PRODUCTION:-}"
+  export POSTHOG_CLI_PROJECT_ID="${POSTHOG_CLI_PROJECT_ID_PRODUCTION:-}"
+  export POSTHOG_CLI_HOST="${POSTHOG_CLI_HOST_PRODUCTION:-${POSTHOG_HOST_PRODUCTION:-}}"
 else
   export GATEWAY_URL="${GATEWAY_URL_PREVIEW:-}"
   export GATEWAY_ADMIN_TOKEN="${GATEWAY_ADMIN_TOKEN_PREVIEW:-}"
+  export VITE_POSTHOG_PROJECT_TOKEN=""
+  export VITE_POSTHOG_HOST=""
+  export POSTHOG_CLI_API_KEY=""
+  export POSTHOG_CLI_PROJECT_ID=""
+  export POSTHOG_CLI_HOST=""
 fi
 
 if [ "$branch" = "$production_branch" ]; then

--- a/scripts/cloudflare-vite-build.sh
+++ b/scripts/cloudflare-vite-build.sh
@@ -11,3 +11,5 @@ export VITE_CONVEX_SITE_URL
 node scripts/gateway-webhook-target.mjs register "${VITE_CONVEX_SITE_URL}/api/github/webhook" || true
 
 pnpm run build
+
+sh scripts/posthog-sourcemaps.sh

--- a/scripts/posthog-sourcemaps.sh
+++ b/scripts/posthog-sourcemaps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -z "${POSTHOG_CLI_API_KEY:-}" ] ||
+  [ -z "${POSTHOG_CLI_PROJECT_ID:-}" ] ||
+  [ -z "${POSTHOG_CLI_HOST:-}" ]; then
+  echo "Skipping PostHog sourcemap upload: missing PostHog CLI environment."
+  exit 0
+fi
+
+if [ ! -d dist ]; then
+  echo "Skipping PostHog sourcemap upload: dist directory does not exist."
+  exit 0
+fi
+
+release_version="${WORKERS_CI_COMMIT_SHA:-${CF_PAGES_COMMIT_SHA:-${GITHUB_SHA:-${VITE_BUILD_ID:-}}}}"
+if [ -z "$release_version" ] && command -v git >/dev/null 2>&1; then
+  release_version="$(git rev-parse HEAD 2>/dev/null || true)"
+fi
+release_version="${release_version:-unknown}"
+
+pnpm exec posthog-cli \
+  --host "$POSTHOG_CLI_HOST" \
+  sourcemap process \
+  --directory dist \
+  --release-name kino \
+  --release-version "$release_version" \
+  --delete-after

--- a/src/components/_default-catch-boundary.tsx
+++ b/src/components/_default-catch-boundary.tsx
@@ -1,5 +1,3 @@
-import type { ErrorComponentProps } from "@tanstack/react-router"
-
 import { useEffect } from "react"
 import { isCancelledError } from "@tanstack/react-query"
 import {
@@ -9,8 +7,10 @@ import {
   useMatch,
   useRouter,
 } from "@tanstack/react-router"
+import type { ErrorComponentProps } from "@tanstack/react-router"
 
 import { RoutePending } from "@/components/route-pending"
+import { captureAppError } from "@/lib/posthog"
 
 function isTransientQueryCancellation(error: unknown) {
   return (
@@ -32,6 +32,15 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
 
     void router.invalidate()
   }, [isQueryCancellation, router])
+
+  useEffect(() => {
+    if (isQueryCancellation) return
+
+    captureAppError(error, {
+      routeErrorBoundary: true,
+      routeId: isRoot ? "root" : "route",
+    })
+  }, [error, isQueryCancellation, isRoot])
 
   if (isQueryCancellation) {
     return <RoutePending variant="page" />

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,27 +1,33 @@
 import type { ReactNode } from "react"
 import type { ConvexQueryClient } from "kitcn/react"
 
+import type { AppEnvironment } from "@/lib/app-env"
 import { CommandProvider } from "@/components/command"
 import { ShortcutsProvider } from "@/components/shortcuts"
 import { AppConvexProvider } from "@/lib/convex/convex-provider"
+import { PostHogProvider } from "@/lib/posthog"
 
 export function Providers({
+  appEnvironment,
   children,
   convexQueryClient,
   initialToken,
 }: {
+  appEnvironment: AppEnvironment
   children: ReactNode
   convexQueryClient: ConvexQueryClient
   initialToken?: string | null
 }) {
   return (
-    <AppConvexProvider
-      convexQueryClient={convexQueryClient}
-      initialToken={initialToken}
-    >
-      <CommandProvider>
-        <ShortcutsProvider>{children}</ShortcutsProvider>
-      </CommandProvider>
-    </AppConvexProvider>
+    <PostHogProvider appEnvironment={appEnvironment}>
+      <AppConvexProvider
+        convexQueryClient={convexQueryClient}
+        initialToken={initialToken}
+      >
+        <CommandProvider>
+          <ShortcutsProvider>{children}</ShortcutsProvider>
+        </CommandProvider>
+      </AppConvexProvider>
+    </PostHogProvider>
   )
 }

--- a/src/lib/convex/query-client.ts
+++ b/src/lib/convex/query-client.ts
@@ -1,70 +1,120 @@
 import {
-  type DefaultOptions,
-  defaultShouldDehydrateQuery,
-  hashKey,
+  MutationCache,
   QueryCache,
   QueryClient,
-} from '@tanstack/react-query';
-import { isCRPCClientError, isCRPCError } from 'kitcn/crpc';
+  defaultShouldDehydrateQuery,
+  hashKey,
+} from "@tanstack/react-query"
+import { isCRPCClientError, isCRPCError } from "kitcn/crpc"
 import {
   ConvexReactClient,
   getConvexQueryClientSingleton,
   getQueryClientSingleton,
-  type AuthStore,
-} from 'kitcn/react';
-import { type Value, convexToJson } from 'convex/values';
-import SuperJSON from 'superjson';
+} from "kitcn/react"
+import { convexToJson } from "convex/values"
+import SuperJSON from "superjson"
+import type { AuthStore } from "kitcn/react"
+import type { DefaultOptions } from "@tanstack/react-query"
+import type { Value } from "convex/values"
 
-export const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL!);
+import { captureAppError } from "@/lib/posthog"
 
-export const hydrationConfig: Pick<DefaultOptions, 'dehydrate' | 'hydrate'> = {
+export const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL)
+
+export const hydrationConfig: Pick<DefaultOptions, "dehydrate" | "hydrate"> = {
   dehydrate: {
     serializeData: SuperJSON.serialize,
     shouldDehydrateQuery: (query) =>
-      defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+      defaultShouldDehydrateQuery(query) || query.state.status === "pending",
     shouldRedactErrors: () => false,
   },
   hydrate: {
     deserializeData: SuperJSON.deserialize,
   },
-};
+}
 
 function stableStringify(value: unknown): string {
-  return JSON.stringify(sortObjectKeys(value));
+  return JSON.stringify(sortObjectKeys(value))
 }
 
 function sortObjectKeys(value: unknown): unknown {
   if (Array.isArray(value)) {
-    return value.map(sortObjectKeys);
+    return value.map(sortObjectKeys)
   }
 
-  if (!value || typeof value !== 'object') {
-    return value;
+  if (!value || typeof value !== "object") {
+    return value
   }
 
   return Object.fromEntries(
     Object.entries(value)
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([key, entry]) => [key, sortObjectKeys(entry)])
-  );
+  )
 }
 
-export function convexQueryKeyHashFn(queryKey: readonly unknown[]) {
-  if (queryKey[0] === 'convexQuery' || queryKey[0] === 'convexAction') {
-    const [, functionName, args] = queryKey;
-    return `${queryKey[0]}|${String(functionName)}|${stableStringify(convexToJson(args as Value))}`;
+export function convexQueryKeyHashFn(queryKey: ReadonlyArray<unknown>) {
+  if (queryKey[0] === "convexQuery" || queryKey[0] === "convexAction") {
+    const [, functionName, args] = queryKey
+    return `${queryKey[0]}|${String(functionName)}|${stableStringify(convexToJson(args as Value))}`
   }
 
-  return hashKey(queryKey);
+  return hashKey(queryKey)
+}
+
+function safeOperationName(operationKey: ReadonlyArray<unknown> | undefined) {
+  if (!operationKey?.length) return undefined
+
+  const [kind, functionName] = operationKey
+
+  if (
+    (kind === "convexQuery" ||
+      kind === "convexAction" ||
+      kind === "convexMutation") &&
+    functionName
+  ) {
+    return `${String(kind)}:${String(functionName)}`
+  }
+
+  return String(kind)
+}
+
+function captureTanStackError(
+  error: unknown,
+  properties: Record<string, unknown>
+) {
+  const crpcProperties = isCRPCClientError(error)
+    ? {
+        crpcCode: error.code,
+        crpcFunctionName: error.functionName,
+        source: "crpc",
+      }
+    : {
+        source: "tanstack-query",
+      }
+
+  captureAppError(error, {
+    ...crpcProperties,
+    ...properties,
+  })
 }
 
 export function createQueryClient() {
   return new QueryClient({
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        captureTanStackError(error, {
+          operationName: safeOperationName(mutation.options.mutationKey),
+          tanstackOperation: "mutation",
+        })
+      },
+    }),
     queryCache: new QueryCache({
-      onError: (error) => {
-        if (isCRPCClientError(error)) {
-          console.warn(`[CRPC] ${error.code}:`, error.functionName);
-        }
+      onError: (error, query) => {
+        captureTanStackError(error, {
+          operationName: safeOperationName(query.queryKey),
+          tanstackOperation: "query",
+        })
       },
     }),
     defaultOptions: {
@@ -72,16 +122,16 @@ export function createQueryClient() {
       queries: {
         queryKeyHashFn: convexQueryKeyHashFn,
         retry: (failureCount, error) => {
-          if (isCRPCError(error)) return false;
-          return failureCount < 3;
+          if (isCRPCError(error)) return false
+          return failureCount < 3
         },
       },
     },
-  });
+  })
 }
 
 export function getAppQueryClient() {
-  return getQueryClientSingleton(createQueryClient);
+  return getQueryClientSingleton(createQueryClient)
 }
 
 export function getAppConvexQueryClient(
@@ -92,16 +142,16 @@ export function getAppConvexQueryClient(
     authStore,
     convex,
     queryClient,
-  });
+  })
 
-  const options = queryClient.getDefaultOptions();
+  const options = queryClient.getDefaultOptions()
   queryClient.setDefaultOptions({
     ...options,
     queries: {
       ...options.queries,
       queryKeyHashFn: convexQueryKeyHashFn,
     },
-  });
+  })
 
-  return convexQueryClient;
+  return convexQueryClient
 }

--- a/src/lib/posthog.tsx
+++ b/src/lib/posthog.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { PostHogProvider as ReactPostHogProvider } from "@posthog/react"
+import { useRouterState } from "@tanstack/react-router"
+import posthog from "posthog-js"
+import { useEffect, useRef } from "react"
+import type { PostHogConfig } from "posthog-js"
+import type { ReactNode } from "react"
+
+import type { AppEnvironment } from "@/lib/app-env"
+import { authClient } from "@/lib/convex/auth-client"
+
+const POSTHOG_TOKEN = import.meta.env.VITE_POSTHOG_PROJECT_TOKEN
+const POSTHOG_HOST = import.meta.env.VITE_POSTHOG_HOST
+
+function canUsePostHog(appEnvironment: AppEnvironment) {
+  return (
+    appEnvironment === "production" &&
+    typeof window !== "undefined" &&
+    !!POSTHOG_TOKEN &&
+    !!POSTHOG_HOST
+  )
+}
+
+function createPostHogOptions(): Partial<PostHogConfig> {
+  return {
+    api_host: POSTHOG_HOST,
+    capture_exceptions: true,
+    capture_pageleave: true,
+    capture_pageview: false,
+    defaults: "2026-05-30",
+    mask_all_element_attributes: true,
+    mask_all_text: true,
+    mask_personal_data_properties: true,
+    person_profiles: "identified_only",
+    session_recording: {
+      blockClass: "ph-no-capture",
+      blockSelector: ".ph-no-capture, [data-ph-no-capture], [data-sensitive]",
+      maskAllInputs: true,
+      maskInputOptions: {
+        color: true,
+        date: true,
+        "datetime-local": true,
+        email: true,
+        month: true,
+        number: true,
+        password: true,
+        range: true,
+        search: true,
+        select: true,
+        tel: true,
+        text: true,
+        textarea: true,
+        time: true,
+        url: true,
+        week: true,
+      },
+      maskTextSelector:
+        ".ph-mask, [data-ph-mask], input, textarea, select, [contenteditable]",
+    },
+  }
+}
+
+let hasInitializedPostHog = false
+
+function ensurePostHog(appEnvironment: AppEnvironment) {
+  if (!canUsePostHog(appEnvironment)) return null
+
+  if (!hasInitializedPostHog) {
+    const token = POSTHOG_TOKEN
+
+    if (!token) return null
+
+    posthog.init(token, createPostHogOptions())
+    hasInitializedPostHog = true
+  }
+
+  return posthog
+}
+
+export function PostHogProvider({
+  appEnvironment,
+  children,
+}: {
+  appEnvironment: AppEnvironment
+  children: ReactNode
+}) {
+  const client = ensurePostHog(appEnvironment)
+
+  if (!client) {
+    return children
+  }
+
+  return (
+    <ReactPostHogProvider client={client}>
+      <PostHogPageviewTracker />
+      <PostHogIdentitySync />
+      {children}
+    </ReactPostHogProvider>
+  )
+}
+
+function PostHogPageviewTracker() {
+  const location = useRouterState({ select: (state) => state.location })
+
+  useEffect(() => {
+    const url = new URL(window.location.href)
+
+    posthog.capture("$pageview", {
+      $current_url: `${url.origin}${location.pathname}`,
+      path: location.pathname,
+    })
+  }, [location.pathname, location.searchStr])
+
+  return null
+}
+
+export function capturePostHogException(
+  error: unknown,
+  properties?: Record<string, unknown>
+) {
+  if (!hasInitializedPostHog) return
+
+  posthog.captureException(error, properties)
+}
+
+export function captureAppError(
+  error: unknown,
+  properties?: Record<string, unknown>
+) {
+  capturePostHogException(error, {
+    appError: true,
+    ...properties,
+  })
+}
+
+function PostHogIdentitySync() {
+  const session = authClient.useSession()
+  const identifiedUserId = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (session.isPending) return
+
+    const user = session.data?.user
+
+    if (!user) {
+      if (identifiedUserId.current) {
+        posthog.reset()
+        identifiedUserId.current = null
+      }
+      return
+    }
+
+    if (identifiedUserId.current === user.id) return
+
+    posthog.identify(user.id, {
+      email: user.email,
+      name: user.name,
+    })
+    identifiedUserId.current = user.id
+  }, [session.data?.user, session.isPending])
+
+  return null
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,3 @@
-import type { ReactNode } from "react"
-import type { QueryClient } from "@tanstack/react-query"
-import type { ConvexQueryClient } from "kitcn/react"
-
 import {
   HeadContent,
   Outlet,
@@ -12,13 +8,16 @@ import {
 import { createServerFn } from "@tanstack/react-start"
 import { TanStackDevtools } from "@tanstack/react-devtools"
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools"
+import appCss from "../styles.css?url"
+import type { ReactNode } from "react"
+import type { QueryClient } from "@tanstack/react-query"
+import type { ConvexQueryClient } from "kitcn/react"
 
 import { DefaultCatchBoundary } from "@/components/_default-catch-boundary"
 import { Providers } from "@/components/providers"
 import { StaleBundleWatcher } from "@/components/stale-bundle-watcher"
 import { Toaster } from "@/components/ui/sonner"
 import { getFaviconHref, inferAppEnvironment } from "@/lib/app-env"
-import appCss from "../styles.css?url"
 
 const getLoaderToken = createServerFn({ method: "GET" }).handler(async () => {
   const { getServerAuthToken } = await import("@/lib/convex/auth-start-token")
@@ -149,9 +148,14 @@ function RootDocument({ children }: { children: ReactNode }) {
 
 function RootComponent() {
   const { convexQueryClient, loaderToken } = Route.useRouteContext()
+  const { appEnvironment } = Route.useLoaderData()
 
   return (
-    <Providers convexQueryClient={convexQueryClient} initialToken={loaderToken}>
+    <Providers
+      appEnvironment={appEnvironment}
+      convexQueryClient={convexQueryClient}
+      initialToken={loaderToken}
+    >
       <Outlet />
     </Providers>
   )

--- a/src/types/build-id.d.ts
+++ b/src/types/build-id.d.ts
@@ -2,3 +2,12 @@
 // stale tab can detect that a newer version has shipped. Present in both the
 // client and server bundles.
 declare const __KINO_BUILD_ID__: string
+
+interface ImportMetaEnv {
+  readonly VITE_POSTHOG_HOST?: string
+  readonly VITE_POSTHOG_PROJECT_TOKEN?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,11 @@ import tailwindcss from "@tailwindcss/vite"
 import { cloudflare } from "@cloudflare/vite-plugin"
 
 const port = process.env.PORT ? Number(process.env.PORT) : undefined
+const uploadPostHogSourcemaps = Boolean(
+  process.env.POSTHOG_CLI_API_KEY &&
+  process.env.POSTHOG_CLI_HOST &&
+  process.env.POSTHOG_CLI_PROJECT_ID
+)
 
 // Stable identifier for the deployed build, baked into both the client and
 // server bundles. Lets a long-lived (stale) tab detect that a newer version has
@@ -40,6 +45,9 @@ function resolveBuildId(): string {
 }
 
 const config = defineConfig({
+  build: {
+    sourcemap: uploadPostHogSourcemaps,
+  },
   define: {
     __KINO_BUILD_ID__: JSON.stringify(resolveBuildId()),
   },


### PR DESCRIPTION
## What changed
- added a production-only PostHog provider for pageviews, exception capture, and auth-backed user identification
- routed route-boundary, TanStack Query, and Convex/cRPC client errors into PostHog error reporting
- enabled sourcemap generation and upload during production Cloudflare builds, with preview builds keeping PostHog disabled

## Why
- this gives the web app client-side observability for runtime errors and navigation activity
- uploaded sourcemaps make captured production stack traces actionable instead of minified

## Follow-up / test notes
- verified with `pnpm run typecheck`
- verified with `pnpm run test`
- production deploys need the PostHog project token and CLI environment variables populated; preview deploys intentionally skip PostHog setup and sourcemap upload