### PR TITLE
[codex] Fix Helmor worktree Convex port conflicts

### DIFF
--- a/scripts/dev-supervisor.mjs
+++ b/scripts/dev-supervisor.mjs
@@ -6,6 +6,7 @@ import {
   anonymousConvexEnv,
   anonymousEnvFilePath as getAnonymousEnvFilePath,
   configuredLocalBackendPort,
+  ensureWorktreeLocalBackendPorts,
   ensureAnonymousEnvFile,
   preserveSharedDevDeployment,
   projectLocalConfigPath as getProjectLocalConfigPath,
@@ -68,6 +69,12 @@ function prepareAnonymousConvex() {
   }
 
   stopLocalBackendForWorkspace(workspaceRoot)
+  const ports = ensureWorktreeLocalBackendPorts(workspaceRoot)
+  if (ports) {
+    console.log(
+      `[convex] using worktree-local Convex ports ${ports.cloud}/${ports.site}`
+    )
+  }
 }
 
 function convexDevArgs() {

--- a/scripts/lib/local-convex.mjs
+++ b/scripts/lib/local-convex.mjs
@@ -149,6 +149,13 @@ function portIsAvailableForWorkspace(port, workspaceRoot) {
   )
 }
 
+function portHasWorkspaceBackend(port, workspaceRoot) {
+  const stateDir = projectLocalStateDir(workspaceRoot)
+  return localBackendPids(port, workspaceRoot).some((pid) =>
+    processCommand(pid, workspaceRoot).includes(stateDir)
+  )
+}
+
 function updateEnvFileValues(filePath, values) {
   const lines = fs.existsSync(filePath)
     ? fs.readFileSync(filePath, "utf8").split(/\r?\n/)
@@ -188,9 +195,16 @@ export function ensureWorktreeLocalBackendPorts(workspaceRoot) {
     Number.isInteger(configuredSite) &&
     portIsAvailableForWorkspace(configuredCloud, workspaceRoot) &&
     portIsAvailableForWorkspace(configuredSite, workspaceRoot)
+  const configuredPortsHaveRunningWorkspaceBackend =
+    Number.isInteger(configuredCloud) &&
+    Number.isInteger(configuredSite) &&
+    (portHasWorkspaceBackend(configuredCloud, workspaceRoot) ||
+      portHasWorkspaceBackend(configuredSite, workspaceRoot))
 
   let ports =
-    configuredPortsAreUsable && configuredCloud !== 3210 && configuredSite !== 3211
+    configuredPortsAreUsable &&
+    (configuredPortsHaveRunningWorkspaceBackend ||
+      (configuredCloud !== 3210 && configuredSite !== 3211))
       ? { cloud: configuredCloud, site: configuredSite }
       : null
 

--- a/scripts/lib/local-convex.mjs
+++ b/scripts/lib/local-convex.mjs
@@ -116,6 +116,110 @@ export function configuredLocalBackendPort(workspaceRoot) {
   }
 }
 
+function hashString(value) {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+function* preferredLocalBackendPorts(workspaceRoot) {
+  const hash = hashString(workspaceRoot)
+  const firstCloudPort = 3300
+  const pairCount = 10000
+  const offset = hash % pairCount
+
+  for (let attempt = 0; attempt < pairCount; attempt += 1) {
+    const cloud = firstCloudPort + ((offset + attempt) % pairCount) * 2
+    yield {
+      cloud,
+      site: cloud + 1,
+    }
+  }
+}
+
+function portIsAvailableForWorkspace(port, workspaceRoot) {
+  const stateDir = projectLocalStateDir(workspaceRoot)
+  const pids = localBackendPids(port, workspaceRoot)
+  return (
+    pids.length === 0 ||
+    pids.every((pid) => processCommand(pid, workspaceRoot).includes(stateDir))
+  )
+}
+
+function updateEnvFileValues(filePath, values) {
+  const lines = fs.existsSync(filePath)
+    ? fs.readFileSync(filePath, "utf8").split(/\r?\n/)
+    : []
+  const seen = new Set()
+  const updated = lines.map((line) => {
+    const match = line.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)(=.*)$/)
+    if (!match || !(match[1] in values)) return line
+
+    seen.add(match[1])
+    return `${match[1]}=${values[match[1]]}`
+  })
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!seen.has(key)) updated.push(`${key}=${value}`)
+  }
+
+  while (updated.length > 0 && updated.at(-1) === "") updated.pop()
+  fs.writeFileSync(filePath, `${updated.join("\n")}\n`)
+}
+
+export function ensureWorktreeLocalBackendPorts(workspaceRoot) {
+  const configPath = projectLocalConfigPath(workspaceRoot)
+  if (!fs.existsSync(configPath)) return null
+
+  let config
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, "utf8"))
+  } catch {
+    return null
+  }
+
+  const configuredCloud = config?.ports?.cloud
+  const configuredSite = config?.ports?.site
+  const configuredPortsAreUsable =
+    Number.isInteger(configuredCloud) &&
+    Number.isInteger(configuredSite) &&
+    portIsAvailableForWorkspace(configuredCloud, workspaceRoot) &&
+    portIsAvailableForWorkspace(configuredSite, workspaceRoot)
+
+  let ports =
+    configuredPortsAreUsable && configuredCloud !== 3210 && configuredSite !== 3211
+      ? { cloud: configuredCloud, site: configuredSite }
+      : null
+
+  if (!ports) {
+    for (const candidate of preferredLocalBackendPorts(workspaceRoot)) {
+      if (
+        portIsAvailableForWorkspace(candidate.cloud, workspaceRoot) &&
+        portIsAvailableForWorkspace(candidate.site, workspaceRoot)
+      ) {
+        ports = { cloud: candidate.cloud, site: candidate.site }
+        break
+      }
+    }
+  }
+
+  if (!ports) return null
+
+  config.ports = { ...(config.ports ?? {}), ...ports }
+  fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`)
+
+  updateEnvFileValues(path.join(workspaceRoot, ".env.local"), {
+    CONVEX_DEPLOYMENT: "anonymous:anonymous-agent",
+    VITE_CONVEX_URL: `http://127.0.0.1:${ports.cloud}`,
+    VITE_CONVEX_SITE_URL: `http://127.0.0.1:${ports.site}`,
+  })
+
+  return ports
+}
+
 export function localBackendPids(port, workspaceRoot = process.cwd()) {
   if (process.platform === "win32") return []
 

--- a/scripts/seed-convex-from-dev.mjs
+++ b/scripts/seed-convex-from-dev.mjs
@@ -555,6 +555,7 @@ const targetEnv = options.target ? process.env : anonymousConvexEnv()
 
 if (!options.target) {
   run("pnpm", ["exec", "convex", "init"], { env: targetEnv })
+  stopRunningLocalBackendIfRequested()
   const ports = ensureWorktreeLocalBackendPorts(workspaceRoot)
   if (ports) {
     console.log(

--- a/scripts/seed-convex-from-dev.mjs
+++ b/scripts/seed-convex-from-dev.mjs
@@ -7,6 +7,7 @@ import {
   anonymousConvexEnv,
   anonymousEnvFilePath as getAnonymousEnvFilePath,
   configuredLocalBackendPort,
+  ensureWorktreeLocalBackendPorts,
   ensureAnonymousEnvFile,
   localBackendPidsForWorkspace,
   preserveSharedDevDeployment,
@@ -554,6 +555,12 @@ const targetEnv = options.target ? process.env : anonymousConvexEnv()
 
 if (!options.target) {
   run("pnpm", ["exec", "convex", "init"], { env: targetEnv })
+  const ports = ensureWorktreeLocalBackendPorts(workspaceRoot)
+  if (ports) {
+    console.log(
+      `[seed] using worktree-local Convex ports ${ports.cloud}/${ports.site}`
+    )
+  }
 }
 
 if (options.copyEnv) {


### PR DESCRIPTION
## Summary

Fixes anonymous Convex local backend port collisions across concurrent Helmor worktrees. Worktrees previously inherited Convex defaults (`3210/3211`), so starting dev in one workspace could fail while another workspace was actively using those ports.

This adds a worktree-local port allocator that stores the selected cloud/site ports in Convex local config and mirrors them into `.env.local`. Startup and seed/bootstrap flows both apply the allocator. Existing non-default ports are kept when usable; default or occupied ports are reassigned from a stable path-derived pool.

The seed path now also handles the review case where `convex init` may touch or leave behind a local backend before ports are rewritten: when seeding was invoked with `--stop-running-local`, it stops this worktree's backend again immediately after `convex init` and before rewriting ports. If a same-worktree backend is already running and seeding was not asked to stop it, the allocator keeps its current ports instead of rewriting config underneath the live process.

## Validation

- `node --check scripts/lib/local-convex.mjs`
- `node --check scripts/dev-supervisor.mjs`
- `node --check scripts/seed-convex-from-dev.mjs`
- Smoke-tested `pnpm run dev` in `hydra`, confirming Convex started on non-default ports (`3432/3433`) and Vite launched successfully.

Full destructive seed flow was not run.