### PR TITLE
Add pnpm dev:stop; keep the shared portless proxy out of reaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "pnpm run dev:anonymous",
     "dev:clean": "node scripts/dev-clean.mjs",
+    "dev:stop": "node scripts/dev-stop.mjs",
     "dev:respread-ports": "node scripts/respread-convex-ports.mjs",
     "dev:anonymous": "KINO_CONVEX_MODE=anonymous node scripts/dev-supervisor.mjs",
     "dev:shared": "KINO_CONVEX_MODE=shared node scripts/dev-supervisor.mjs",

--- a/scripts/dev-stop.mjs
+++ b/scripts/dev-stop.mjs
@@ -1,0 +1,21 @@
+// Stop every dev process belonging to THIS worktree — the Convex CLI, its local
+// backend, Vite, Cloudflare workerd, and the portless client — whether they are
+// still running or were orphaned by a non-graceful stop. The shared portless
+// proxy on :1355 is left running because other worktrees route through it.
+//
+// Usage: pnpm run dev:stop  (from inside the worktree)
+
+import { stopStaleWorktreeProcesses } from "./lib/local-convex.mjs"
+
+const workspaceRoot = process.cwd()
+const stopped = stopStaleWorktreeProcesses(workspaceRoot)
+
+if (stopped.length > 0) {
+  console.log(
+    `[dev:stop] stopped ${stopped.length} dev process(es) for this worktree: ${stopped.join(
+      ", "
+    )}`
+  )
+} else {
+  console.log("[dev:stop] no dev processes are running for this worktree.")
+}

--- a/scripts/dev-supervisor.mjs
+++ b/scripts/dev-supervisor.mjs
@@ -63,7 +63,14 @@ function prepareAnonymousConvex() {
   // stopped `pnpm dev` of this worktree. Otherwise orphaned `convex dev` CLIs
   // (whose backend is gone) retry forever and spam the console, and they pile up
   // one stack per run.
-  stopStaleWorktreeProcesses(workspaceRoot)
+  const reaped = stopStaleWorktreeProcesses(workspaceRoot)
+  if (reaped.length > 0) {
+    console.log(
+      `[dev] reaped ${reaped.length} stale dev process(es) from a previous run: ${reaped.join(
+        ", "
+      )}`
+    )
+  }
 
   preserveSharedDevDeployment(workspaceRoot, "scripts/dev-supervisor.mjs")
   ensureAnonymousEnvFile(workspaceRoot)

--- a/scripts/lib/local-convex.mjs
+++ b/scripts/lib/local-convex.mjs
@@ -426,11 +426,16 @@ export function stopLocalBackendForWorkspace(
 // The supervisor's own command is relative (`node scripts/dev-supervisor.mjs`)
 // and its pnpm/sh parents don't carry the worktree path, so they're never hit;
 // we also skip our own pid and parent for safety.
-export function stopStaleWorktreeProcesses(
-  workspaceRoot,
-  { logPrefix = "[dev]" } = {}
-) {
-  if (process.platform === "win32") return
+//
+// The shared portless proxy daemon (`portless … proxy start`) is deliberately
+// left alone even if it was started from this worktree's node_modules — every
+// other worktree routes through it on :1355, so killing it would drop their
+// tunnels. Only this worktree's portless *client* is stopped.
+//
+// Returns the list of pids it signalled (empty when nothing matched), so callers
+// can decide how to report it.
+export function stopStaleWorktreeProcesses(workspaceRoot) {
+  if (process.platform === "win32") return []
 
   const marker = workspaceRoot.endsWith(path.sep)
     ? workspaceRoot
@@ -443,7 +448,7 @@ export function stopStaleWorktreeProcesses(
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
   })
-  if (result.status !== 0 || !result.stdout) return
+  if (result.status !== 0 || !result.stdout) return []
 
   const victims = []
   for (const line of result.stdout.split("\n")) {
@@ -454,7 +459,13 @@ export function stopStaleWorktreeProcesses(
     if (pid === self || pid === parent) continue
     if (!command.includes(marker)) continue
 
-    const isStaleDevProcess =
+    // Never touch the shared portless proxy daemon, even if it was launched from
+    // this worktree — other worktrees depend on it.
+    const isPortlessProxyDaemon =
+      /\/portless\/[^\s]*cli\.js\b[\s\S]*\bproxy\b[\s\S]*\bstart\b/.test(command)
+    if (isPortlessProxyDaemon) continue
+
+    const isWorktreeDevProcess =
       /\/convex\/bin\/main\.js\b[\s\S]*\bdev\b/.test(command) ||
       (command.includes("convex-local-backend") &&
         command.includes(stateDir)) ||
@@ -462,18 +473,13 @@ export function stopStaleWorktreeProcesses(
       command.includes("workerd serve") ||
       /\/portless\/[^\s]*cli\.js\b/.test(command)
 
-    if (isStaleDevProcess) victims.push(pid)
+    if (isWorktreeDevProcess) victims.push(pid)
   }
 
-  if (victims.length === 0) return
+  if (victims.length === 0) return []
 
-  console.log(
-    `${logPrefix} reaping ${victims.length} stale dev process(es) from a previous run: ${victims.join(
-      ", "
-    )}`
-  )
   terminatePids(victims, "SIGTERM")
-  if (waitForPidsToStop(victims, 5000)) return
+  if (waitForPidsToStop(victims, 5000)) return victims
 
   const remaining = victims.filter((pid) => {
     try {
@@ -485,4 +491,5 @@ export function stopStaleWorktreeProcesses(
   })
   terminatePids(remaining, "SIGKILL")
   waitForPidsToStop(remaining, 2000)
+  return victims
 }


### PR DESCRIPTION
Follow-up to #83 (port collisions) and #84 (orphan reaper).

## What
- **`pnpm run dev:stop`** (`scripts/dev-stop.mjs`): stops every dev process for the current worktree — Convex CLI, local backend, Vite, Cloudflare `workerd`, and the portless client — whether running or orphaned. Intended for retiring a finished worktree, where the startup reaper (#84) would otherwise never run again.
- **Never reap the shared portless proxy.** `stopStaleWorktreeProcesses` now skips the `portless … proxy start` daemon even when it was launched from this worktree's `node_modules`, so cleanup can't drop other worktrees' tunnels on `:1355`.
- `stopStaleWorktreeProcesses` returns the signalled pids instead of logging internally; callers report it (supervisor: "reaped … from a previous run"; dev:stop: "stopped …").

## Why
The #84 reaper matched portless by `node_modules/portless/.../cli.js`, which also matches the shared proxy daemon when that daemon happens to have been started from the worktree being cleaned — so a `pnpm dev` (or future stop) in that worktree could restart the proxy and blip every other worktree. This scopes cleanup to the worktree's own client processes only.

## Verification
Ran `pnpm run dev:stop` in a worktree whose `node_modules` had started the shared proxy:
- stopped that worktree's 5 dev processes ✓
- left the `:1355` proxy daemon running ✓
- two other worktrees' stacks fully intact ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)