### PR TITLE
Start the shared portless proxy from a neutral location

### DIFF
--- a/scripts/dev-portless.sh
+++ b/scripts/dev-portless.sh
@@ -5,4 +5,43 @@ name="$(sh scripts/portless-name.sh kino)"
 
 export PORTLESS_PORT="${PORTLESS_PORT:-1355}"
 
+# Ensure the shared portless proxy is running BEFORE registering this worktree's
+# route.
+#
+#   - Proxy already up  -> do nothing; just register our route and share it.
+#   - Proxy not up      -> start it, so we and every later worktree share one proxy.
+#
+# When we have to start it, we start it from the GLOBAL portless install (not this
+# worktree's local copy) and from a neutral working directory, so the daemon's
+# command line carries no worktree path. That keeps the proxy "owned by nobody":
+# no worktree's dev cleanup can match and kill it, so starting or stopping one
+# worktree never disturbs another. The proxy is shared infrastructure; each
+# `pnpm dev` only ever brings up its OWN Convex/Vite and registers a route.
+proxy_is_up() {
+  curl -sk -o /dev/null --max-time 2 "https://127.0.0.1:${PORTLESS_PORT}/" 2>/dev/null
+}
+
+if ! proxy_is_up; then
+  # Prefer the global install so the daemon isn't tied to any worktree's folder.
+  global_root="$(npm root -g 2>/dev/null || true)"
+  global_cli="${global_root}/portless/dist/cli.js"
+  if [ -n "${global_root}" ] && [ -f "${global_cli}" ]; then
+    (cd "${HOME}" && node "${global_cli}" proxy start --https --skip-trust >/dev/null 2>&1 &)
+  else
+    # Fallback: let whatever `portless` is on PATH start it. Still a shared proxy;
+    # just not started from a guaranteed-neutral path.
+    (cd "${HOME}" && portless proxy start --https --skip-trust >/dev/null 2>&1 &)
+  fi
+
+  # Wait for it to listen, regardless of which worktree won a concurrent start.
+  i=0
+  while [ "${i}" -lt 20 ]; do
+    if proxy_is_up; then
+      break
+    fi
+    i=$((i + 1))
+    sleep 0.3
+  done
+fi
+
 exec portless "$name" --force "$@"


### PR DESCRIPTION
## What you asked for
> `pnpm run dev` should check if the shared proxy is up — if it is, do nothing; if not, create it so it (and later worktrees) can share it — and the proxy shouldn't be "owned" by any one worktree.

That's exactly this change.

## The problem
`pnpm run dev` already auto-starts the portless proxy on first use, but portless cold-starts it from **that worktree's** `node_modules`. So the proxy daemon's command line contains a worktree path → it's matchable by that worktree's dev cleanup → restarting the owning worktree could take the shared proxy (and every other worktree's tunnel) down with it. That's the "starting one dev kills the other" class of bug.

## The change (`scripts/dev-portless.sh`)
Before registering this worktree's route, ensure the proxy is up:
- **Proxy already up** → no-op; just register our route and share it.
- **Proxy not up** → start it from the **global** install (`npm root -g`) in a neutral working dir, so the daemon carries **no worktree path** and is owned by nobody.

The proxy becomes shared infrastructure that comes up with the first `pnpm run dev` and that no single worktree owns or can kill. Each dev run only ever brings up its own Convex/Vite and adds a route — full isolation, proxy still shared (auth needs it).

Note: not a background/login service — it starts on first `dev`, lingers idle after (harmless), and can be stopped with `pnpm run dev:stop` / `portless proxy stop`. Auto-stopping on "last dev exits" was intentionally avoided — it requires fragile cross-worktree refcounting that, done wrong, reintroduces the cross-kill.

## Verification
- **Proxy down →** `dev-portless.sh` cold-starts a **neutral** proxy (confirmed no worktree path in its command), and the other running worktrees recovered to **HTTP 200** automatically.
- **Proxy up →** reuses the same daemon, starts no new process (`-- Proxy is running`).
- Test routes cleaned up; `routes.json` left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)