### PR TITLE
Reset mismatched local Convex deployment before seeding

### DIFF
--- a/scripts/seed-convex-from-dev.mjs
+++ b/scripts/seed-convex-from-dev.mjs
@@ -11,6 +11,7 @@ import {
   ensureAnonymousEnvFile,
   localBackendPidsForWorkspace,
   preserveSharedDevDeployment,
+  projectLocalConfigPath as getProjectLocalConfigPath,
   readEnvFile,
   sharedDevStatePath as getSharedDevStatePath,
   sleep,
@@ -277,6 +278,34 @@ function stopRunningLocalBackendIfRequested() {
   ) {
     process.exit(1)
   }
+}
+
+// A prior run can leave a local deployment whose name isn't "anonymous-agent" —
+// e.g. the legacy `kitcn dev` flow, or a newer Convex that names anonymous
+// deployments after the directory (anonymous-<dir>). `convex init` then reuses
+// that deployment, and the later `convex env set` (which copies JWKS and other
+// auth vars from shared dev) fails with "Could not find deployment with name
+// anonymous-agent". Reset the local state so init creates a clean anonymous-agent
+// deployment. Only acts on a mismatch, so the normal re-seed path is untouched.
+function resetMismatchedLocalDeployment() {
+  const configPath = getProjectLocalConfigPath(workspaceRoot)
+  if (!fs.existsSync(configPath)) return
+
+  let existingName
+  try {
+    existingName = JSON.parse(fs.readFileSync(configPath, "utf8"))?.deploymentName
+  } catch {
+    return
+  }
+
+  if (typeof existingName !== "string" || !existingName) return
+  if (existingName === "anonymous-agent") return
+
+  const localStateDir = path.dirname(path.dirname(configPath)) // .convex/local
+  console.log(
+    `[seed] local deployment is "${existingName}", not "anonymous-agent"; resetting it for a clean anonymous seed`
+  )
+  fs.rmSync(localStateDir, { recursive: true, force: true })
 }
 
 function timestamp() {
@@ -554,6 +583,7 @@ const sourceDeployment =
 const targetEnv = options.target ? process.env : anonymousConvexEnv()
 
 if (!options.target) {
+  resetMismatchedLocalDeployment()
   run("pnpm", ["exec", "convex", "init"], { env: targetEnv })
   stopRunningLocalBackendIfRequested()
   const ports = ensureWorktreeLocalBackendPorts(workspaceRoot)


### PR DESCRIPTION
Hardening discovered while debugging a worktree that wouldn't start (`JWKS … not set`).

## Problem
The seed assumes the worktree's local anonymous deployment is named **`anonymous-agent`**. But a prior run can leave a *different* name:
- the legacy `kitcn dev` flow, or
- a newer Convex that names anonymous deployments after the directory (`anonymous-<dir>`).

`convex init` then **reuses** that mis-named deployment, so the later `convex env set` — which copies `JWKS` and other auth vars from shared dev — fails with:
```
✖ Could not find deployment with name anonymous-agent!
```
The seed bails, `JWKS` is never set, and `pnpm run dev` errors on the missing auth env var.

## Fix
`resetMismatchedLocalDeployment()` runs right before `convex init`: if the existing local deployment's name isn't `anonymous-agent`, it removes `.convex/local` so init recreates a clean `anonymous-agent` deployment. **Only acts on a mismatch** — the normal re-seed path (already `anonymous-agent`, possibly with data) is untouched.

This is the exact manual recovery that unblocked the affected worktree; baking it in makes the seed self-healing.

## Verification
- Logic test: mismatched name → `.convex/local` reset; `anonymous-agent` → kept.
- `node --check` passes; the new `projectLocalConfigPath` import resolves.
- Real-world: the same reset (done by hand) let a stuck worktree seed cleanly to exit 0 (275 docs imported, `JWKS` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)