### PR TITLE
[codex] Add app custom domains to Wrangler

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,10 @@
   "compatibility_date": "2026-05-22",
   "compatibility_flags": ["nodejs_compat"],
   "main": "@tanstack/react-start/server-entry",
+  "routes": [
+    { "pattern": "usekino.com", "custom_domain": true },
+    { "pattern": "www.usekino.com", "custom_domain": true },
+  ],
   "preview_urls": true,
   "observability": { "enabled": true },
 }


### PR DESCRIPTION
## Summary

Adds `usekino.com` and `www.usekino.com` as Wrangler custom-domain routes for the main `kino` Worker.

## Why

`www.usekino.com` is proxied through Cloudflare but currently fails TLS before redirect rules can run because the hostname does not have an active edge certificate. Worker custom domains should let Cloudflare manage the DNS/certificate attachment for the app Worker without requiring paid ACM.

## Validation

- Ran `pnpm run build` successfully.
- Confirmed the generated deploy artifact `dist/server/wrangler.json` includes both custom-domain route entries.

## Notes

Preview branches use the existing preview upload flow. After this PR opens, check the Cloudflare preview build logs to confirm the preview upload does not try to attach or reassign the production custom domains.